### PR TITLE
feat: social_signup_signin

### DIFF
--- a/src/main/java/com/joyride/ms/JoyrideServerApplication.java
+++ b/src/main/java/com/joyride/ms/JoyrideServerApplication.java
@@ -1,10 +1,20 @@
 package com.joyride.ms;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+@EnableScheduling
 @SpringBootApplication
 public class JoyrideServerApplication {
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(JoyrideServerApplication.class, args);

--- a/src/main/java/com/joyride/ms/src/auth/PrincipalOAuth2UserService.java
+++ b/src/main/java/com/joyride/ms/src/auth/PrincipalOAuth2UserService.java
@@ -1,32 +1,41 @@
 package com.joyride.ms.src.auth;
 
+import com.joyride.ms.src.auth.dto.GetOauth2UserRes;
+import com.joyride.ms.src.auth.dto.PostSignupOauth2Req;
 import com.joyride.ms.src.auth.model.PrincipalDetails;
+import com.joyride.ms.src.user.UserDao;
 import com.joyride.ms.src.user.UserProvider;
 import com.joyride.ms.src.user.UserService;
 import com.joyride.ms.src.user.model.User;
 import com.joyride.ms.util.BaseException;
+import com.joyride.ms.util.BaseResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+
+import static com.joyride.ms.util.BaseResponseStatus.SUCCESS;
+
 @Slf4j
 @Service
 public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserProvider userProvider;
+    private final UserService userService;
+
+
 
     @Autowired
-    public PrincipalOAuth2UserService(UserProvider userProvider) {
+    public PrincipalOAuth2UserService(UserProvider userProvider, UserService userService) {
         this.userProvider = userProvider;
+        this.userService = userService;
     }
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        log.info("test");
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
         String name = (String) oAuth2User.getAttributes().get("name");
@@ -35,6 +44,8 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
         String provider_id = (String) oAuth2User.getAttributes().get("sub");
 
         User user = null;
+        User newUser = null;
+
         // todo: 회원가입된 소셜계정 validate
         try {
             if (userProvider.checkEmail(email, provider) == 1)
@@ -47,7 +58,15 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
             user = new User(name,email,"", "",null,"","", provider, provider_id);
             // 여기서 회원 가입 실제로 하지 않고, 가능 여부 파악 후 클라이언트에서 /auth/signup/oauth2 api 호출하여 실제 회원가입함
 
-            return new PrincipalDetails(user, oAuth2User.getAttributes(), true);
+            PostSignupOauth2Req postSignupOauth2Req = new PostSignupOauth2Req(email,provider,provider_id,true);
+
+            try{
+                userService.createOauth2User(postSignupOauth2Req);
+                newUser = userProvider.retrieveByEmail(email, provider);
+            }catch (BaseException e) {
+                throw new RuntimeException(e);
+            }
+            return new PrincipalDetails(newUser, oAuth2User.getAttributes(), true);
         } else {
             log.info("구글 로그인 기록이 있습니다. 로그인을 진행합니다.");
             return new PrincipalDetails(user, oAuth2User.getAttributes(), false);

--- a/src/main/java/com/joyride/ms/src/config/SecurityConfig.java
+++ b/src/main/java/com/joyride/ms/src/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.joyride.ms.src.jwt.handler.CustomAccessDeniedHandler;
 import com.joyride.ms.src.jwt.handler.CustomAuthenticationEntryPointHandler;
 import com.joyride.ms.src.jwt.handler.OAuth2SuccessHandler;
 import com.joyride.ms.src.user.UserProvider;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,19 +17,13 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@Slf4j
 public class SecurityConfig {
 
     private final PrincipalOAuth2UserService principalOAuth2UserService;
@@ -91,9 +86,5 @@ public class SecurityConfig {
                 .successHandler(new OAuth2SuccessHandler(jwtTokenProvider, authService));
 
         return http.build();
-    }
-        @Bean
-    public PasswordEncoder passwordEncoder(){
-        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/joyride/ms/src/jwt/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/joyride/ms/src/jwt/handler/OAuth2SuccessHandler.java
@@ -45,7 +45,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .path("/")
                 .build();
         response.setHeader("Set-Cookie", cookie.toString());
-        String targetUri = "http://localhost:3000/login";
+        String targetUri = "http://localhost:3000";
 
         getRedirectStrategy().sendRedirect(request,response,targetUri);
     }

--- a/src/main/java/com/joyride/ms/src/jwt/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/joyride/ms/src/jwt/handler/OAuth2SuccessHandler.java
@@ -13,10 +13,6 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,7 +20,6 @@ import java.io.IOException;
 
 @RequiredArgsConstructor
 @Component
-@RestController
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -38,36 +33,18 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.setCharacterEncoding("utf-8");
 
         PrincipalDetails oAuth2User = (PrincipalDetails) authentication.getPrincipal();
+        System.out.println(oAuth2User.getUser().getId());
+        Token token = jwtTokenProvider.createToken(oAuth2User.getUser().getId());
+        String refreshToken = token.getRefreshToken();
 
-        GetOauth2SuccessRes getOauth2SuccessRes;
-        if (oAuth2User.isNewUser()) { // 새로 가입한 유저
-            GetOauth2UserRes getOauth2UserRes = new GetOauth2UserRes(oAuth2User.getUser().getNickname(),
-                    oAuth2User.getUser().getEmail(), oAuth2User.getUser().getProvider(), oAuth2User.getUser().getProvider_id());
-            getOauth2SuccessRes = new GetOauth2SuccessRes(true, getOauth2UserRes);
-            ResponseCookie cookie = ResponseCookie.from("providerId",getOauth2SuccessRes.getUser().getProviderId())
-                    .httpOnly(true)
-                    .path("/")
-                    .build();
-            response.setHeader("Set-Cookie", cookie.toString());
+        authService.registerRefreshToken(oAuth2User.getUser().getId(), refreshToken);
 
-        } else { // 기존 유저
-
-            Token token = jwtTokenProvider.createToken(oAuth2User.getUser().getId());
-            String accessToken = token.getAccessToken();
-            String refreshToken = token.getRefreshToken();
-
-            authService.registerRefreshToken(oAuth2User.getUser().getId(), refreshToken);
-            getOauth2SuccessRes = new GetOauth2SuccessRes(false, accessToken);
-
-            ResponseCookie cookie = ResponseCookie.from("refreshToken",refreshToken)
-                    .maxAge(90 * 24 *60 *60)
-                    .httpOnly(true)
-                    .path("/")
-                    .build();
-            response.setHeader("Set-Cookie", cookie.toString());
-        }
-        String result = objectMapper.writeValueAsString(new BaseResponse<>(getOauth2SuccessRes));
-        response.getWriter().write(result);
+        ResponseCookie cookie = ResponseCookie.from("refreshToken",refreshToken)
+                .maxAge(90 * 24 *60 *60)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        response.setHeader("Set-Cookie", cookie.toString());
         String targetUri = "http://localhost:3000/login";
 
         getRedirectStrategy().sendRedirect(request,response,targetUri);

--- a/src/main/java/com/joyride/ms/src/user/UserService.java
+++ b/src/main/java/com/joyride/ms/src/user/UserService.java
@@ -6,6 +6,7 @@ import com.joyride.ms.util.BaseException;
 import com.joyride.ms.util.BaseResponseStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -23,7 +24,7 @@ public class UserService {
     private final UserDao userDao;
 
     @Autowired
-    public UserService(PasswordEncoder passwordEncoder, UserProvider userProvider, UserDao userDao) {
+    public UserService( PasswordEncoder passwordEncoder, UserProvider userProvider, UserDao userDao) {
         this.passwordEncoder = passwordEncoder;
         this.userProvider = userProvider;
         this.userDao = userDao;


### PR DESCRIPTION
## 관련 이슈
- 소셜 회원가입시 가입 후 refreshToken발급
- 기존 유저시 refreshToken발급
closes #29 

## 작업 내용
securityconfig에 등록한 passwordEncoder를 userService에서 빈 객체 생성시 error 발생
->boot실행시 auth package를 config package보다 먼저 읽어서 일어나는 순환참조 에러
-> securityconfig에서 빈등록하지않고 applicationserver(main)에서 등록
## Test scenario or New setup

_(ex: 라이브러리 추가되었습니다.)_
