### PR TITLE
feat: user_api & change pk type long -> integer

### DIFF
--- a/src/main/java/com/joyride/ms/src/auth/AuthController.java
+++ b/src/main/java/com/joyride/ms/src/auth/AuthController.java
@@ -70,7 +70,7 @@ public class AuthController {
         }
         try {
             String encodedPassword = passwordEncoder.encode(postSignupReq.getPassword());
-            User user = new User(postSignupReq.getNickname(), postSignupReq.getEmail(), encodedPassword, postSignupReq.getGender(), postSignupReq.getOld(), postSignupReq.getBicycleType(), "ROLE_USER", "none", "none");
+            User user = new User(postSignupReq.getNickname(), postSignupReq.getEmail(), encodedPassword, postSignupReq.getGender(), postSignupReq.getOld(), postSignupReq.getBicycleType(),postSignupReq.getBicycleCareer(), "ROLE_USER", "none", "none");
             userService.createUser(user, postSignupReq.isTermsEnable());
             return new BaseResponse<>(SUCCESS);
         } catch (BaseException e) {
@@ -104,7 +104,7 @@ public class AuthController {
         }
         PrincipalDetails userEntity = (PrincipalDetails) authentication.getPrincipal();
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        Long userId = userEntity.getUser().getId();
+        Integer userId = userEntity.getUser().getId();
 
         Token token = jwtTokenProvider.createToken(userId);
         String accessToken = token.getAccessToken();
@@ -149,7 +149,7 @@ public class AuthController {
 
         PrincipalDetails userEntity = (PrincipalDetails) authentication.getPrincipal();
 
-        Long userId = userEntity.getUser().getId();
+        Integer userId = userEntity.getUser().getId();
 
         Token token = jwtTokenProvider.createToken(userId);
         String accessToken = token.getAccessToken();

--- a/src/main/java/com/joyride/ms/src/auth/AuthDao.java
+++ b/src/main/java/com/joyride/ms/src/auth/AuthDao.java
@@ -15,7 +15,7 @@ public class AuthDao {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
-    public boolean checkUser(Long userId) {
+    public boolean checkUser(Integer userId) {
         String checkUserQuery = "select exists(select user_id from token where user_id=?)";
 
         int result = this.jdbcTemplate.queryForObject(checkUserQuery, int.class, userId);
@@ -26,7 +26,7 @@ public class AuthDao {
         return true;
     }
 
-    public Long insertRefreshToken(Long userId, String refreshToken) {
+    public Integer insertRefreshToken(Integer userId, String refreshToken) {
         String insertRefreshTokenQuery = "insert into token(user_id, refresh_token) values (?,?)";
         Object[] insertRefreshTokenParams = new Object[]{userId, refreshToken};
 
@@ -35,7 +35,7 @@ public class AuthDao {
         return userId;
     }
 
-    public String updateRefreshToken(Long userId, String newRefreshToken) {
+    public String updateRefreshToken(Integer userId, String newRefreshToken) {
         String updateRefreshTokenQuery = "update token set refresh_token = ? where user_id=?";
         Object[] updateRefreshTokenParams = new Object[]{newRefreshToken,userId};
 

--- a/src/main/java/com/joyride/ms/src/auth/AuthService.java
+++ b/src/main/java/com/joyride/ms/src/auth/AuthService.java
@@ -19,7 +19,7 @@ public class AuthService {
         this.jwtTokenProvider = jwtTokenProvider;
     }
     @Transactional
-    public Long registerRefreshToken(Long userId, String refreshToken) {
+    public Integer registerRefreshToken(Integer userId, String refreshToken) {
         if(authDao.checkUser(userId))
             authDao.updateRefreshToken(userId, refreshToken);
         else
@@ -30,7 +30,7 @@ public class AuthService {
     @Transactional
     public String createAccess(String refreshToken) throws BaseException {
 
-        Long userId = Long.parseLong(jwtTokenProvider.getUseridFromRef(refreshToken));
+        Integer userId = Integer.parseInt(jwtTokenProvider.getUseridFromRef(refreshToken));
 
         String newAccessToken = jwtTokenProvider.createAccessToken(userId);
 

--- a/src/main/java/com/joyride/ms/src/auth/PrincipalOAuth2UserService.java
+++ b/src/main/java/com/joyride/ms/src/auth/PrincipalOAuth2UserService.java
@@ -50,7 +50,7 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
         }
         if (user == null) {
             log.info("구글 로그인 최초입니다. 회원가입을 진행합니다.");
-            user = new User(name,email,"", "",null,"","", provider, provider_id);
+            user = new User(name,email,"", "",null,"",null,"", provider, provider_id);
             // 여기서 회원 가입 실제로 하지 않고, 가능 여부 파악 후 클라이언트에서 /auth/signup/oauth2 api 호출하여 실제 회원가입함
 
             PostSignupOauth2Req postSignupOauth2Req = new PostSignupOauth2Req(email,provider,provider_id,true);

--- a/src/main/java/com/joyride/ms/src/auth/dto/PostSignupReq.java
+++ b/src/main/java/com/joyride/ms/src/auth/dto/PostSignupReq.java
@@ -19,9 +19,11 @@ public class PostSignupReq {
     private String email;
     @NotBlank(message="패스워드는 필수 입력값입니다.")
     private String password;
+    @Size(min=1, max=1,message="gender: m/f")
     private String gender; // m/f
     private Integer old;
     private String bicycleType;
+    private Integer bicycleCareer;
     @JsonProperty("isTermsEnable")
     private boolean isTermsEnable;
 }

--- a/src/main/java/com/joyride/ms/src/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/joyride/ms/src/jwt/JwtTokenProvider.java
@@ -59,7 +59,7 @@ public class JwtTokenProvider {
 
     // JWT 토큰 생성
 
-    public Token createToken(Long userId) {
+    public Token createToken(Integer userId) {
         Claims claims = Jwts.claims().setSubject(userId.toString()); // JWT payload 에 저장되는 정보단위, 보통 여기서 user를 식별하는 값을 넣는다.
         Date now = new Date();
 
@@ -81,7 +81,7 @@ public class JwtTokenProvider {
         return new Token(accessToken, refreshToken);
     }
 
-    public String createAccessToken(Long userId) {
+    public String createAccessToken(Integer userId) {
         Claims claims = Jwts.claims().setSubject(userId.toString()); // JWT payload 에 저장되는 정보단위, 보통 여기서 user를 식별하는 값을 넣는다.
 
         Date now = new Date();
@@ -93,7 +93,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createRefreshToken(Long userId) {
+    public String createRefreshToken(Integer userId) {
         Claims claims = Jwts.claims().setSubject(userId.toString()); // JWT payload 에 저장되는 정보단위, 보통 여기서 user를 식별하는 값을 넣는다.
 
         Date now = new Date();

--- a/src/main/java/com/joyride/ms/src/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/joyride/ms/src/jwt/filter/JwtAuthorizationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             String jwtHeader = request.getHeader("Authorization");
 
             if (StringUtils.hasText(jwtHeader) && jwtTokenProvider.validateToken(jwtHeader)) {
-                Long userId = Long.parseLong(jwtTokenProvider.getUseridFromAcs(jwtHeader));
+                Integer userId = Integer.parseInt(jwtTokenProvider.getUseridFromAcs(jwtHeader));
 
                 Collection<GrantedAuthority> userAuthorities = new ArrayList<>();
                 userAuthorities.add(new GrantedAuthority() {

--- a/src/main/java/com/joyride/ms/src/user/UserController.java
+++ b/src/main/java/com/joyride/ms/src/user/UserController.java
@@ -10,7 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -73,11 +75,14 @@ public class UserController {
      * @return
      */
     @PostMapping("/signout")
-    public BaseResponse<BaseResponseStatus> signout(HttpServletRequest request) {
+    public BaseResponse<BaseResponseStatus> signout(HttpServletRequest request, HttpServletResponse response) {
         try {
             Integer userId = Integer.parseInt(request.getAttribute("user_id").toString());
             /* remove refreshToken */
             userService.removeRefreshToken(userId);
+            Cookie cookie = new Cookie("refreshToken",null);
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/src/main/java/com/joyride/ms/src/user/UserController.java
+++ b/src/main/java/com/joyride/ms/src/user/UserController.java
@@ -1,0 +1,107 @@
+package com.joyride.ms.src.user;
+
+import com.joyride.ms.src.user.dto.GetUserRes;
+import com.joyride.ms.src.user.model.User;
+import com.joyride.ms.util.BaseException;
+import com.joyride.ms.util.BaseResponse;
+import com.joyride.ms.util.BaseResponseStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Slf4j
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserProvider userProvider;
+    private final UserService userService;
+
+    @Autowired
+    public UserController(UserProvider userProvider, UserService userService) {
+        this.userProvider = userProvider;
+        this.userService = userService;
+    }
+
+    /**
+     * 2.1 프로필 조회 api :todoId
+     * [GET] /users/:userId
+     *
+     * @param request
+     * @return profileImgUrl, nickname, gender, manner, old, introduce, bicycleType, bicycleCareer
+     * @throws BaseException
+     */
+    @GetMapping("{userId}")
+    public BaseResponse<GetUserRes> getProfile(HttpServletRequest request, @PathVariable("userId") Integer userId) {
+        try {
+            User user = userProvider.retrieveById(userId);
+            GetUserRes getUserRes = new GetUserRes(user.getProfile_img_url(), user.getNickname(),user.getGender(),user.getManner(),user.getOld(), user.getIntroduce(), user.getBicycleType(), user.getBicycleCareer());
+            return new BaseResponse<>(getUserRes);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 2.2 유저 삭제 API
+     * [PATCH] /users/status
+     *
+     * @param request
+     * @return
+     */
+    @PatchMapping("/status")
+    public BaseResponse<BaseResponseStatus> patchUserStatus(HttpServletRequest request) {
+        try {
+            Integer user_id = Integer.parseInt(request.getAttribute("user_id").toString());
+            userService.removeUser(user_id);
+            return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 2.3 로그아웃 API
+     * [POST] /users/signout
+     *
+     * @param request
+     * @return
+     */
+    @PostMapping("/signout")
+    public BaseResponse<BaseResponseStatus> signout(HttpServletRequest request) {
+        try {
+            Integer userId = Integer.parseInt(request.getAttribute("user_id").toString());
+            /* remove refreshToken */
+            userService.removeRefreshToken(userId);
+            return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+    * 보관기간 1달 지난 유저 삭제
+    *
+    *
+    *
+    */
+    @Scheduled(cron = "0 0 0 1/1 * ?")
+    public void UserRemove() throws BaseException {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        String targetDate = dateFormat.format(new Date());
+
+        try {
+            userService.removeUserExpired(targetDate);
+            log.info("보관기간이 만료된 비활성화 계정들을 삭제하는데 성공했습니다.");
+        } catch (BaseException e) {
+            log.error(e.getMessage(), "유저 삭제 실패 | UserController/UserRemove()");
+        }
+    }
+
+}
+

--- a/src/main/java/com/joyride/ms/src/user/UserDao.java
+++ b/src/main/java/com/joyride/ms/src/user/UserDao.java
@@ -21,13 +21,13 @@ public class UserDao {
 
 
     public User insertUser(User user, boolean isTermsEnable) {
-        String insertUserQuery = "insert into user (nickname,email,password,gender,old,bicycle_type,role,provider,provider_id, terms) values (?,?,?,?,?,?,?,?,?, ?)";
+        String insertUserQuery = "insert into user (nickname,email,password,gender,old,bicycle_type,bicycle_career,role,provider,provider_id, terms) values (?,?,?,?,?,?,?,?,?,?,?)";
         Object[] insertUserParams = new Object[]{user.getNickname(), user.getEmail(), user.getPassword(), user.getGender(), user.getOld(),
-                user.getBicycleType(),user.getRole(), user.getProvider(), user.getProvider_id(), isTermsEnable};
+                user.getBicycleType(),user.getBicycleCareer(),user.getRole(), user.getProvider(), user.getProvider_id(), isTermsEnable};
 
         this.jdbcTemplate.update(insertUserQuery, insertUserParams);
 
-        Long lastInsertId = this.jdbcTemplate.queryForObject("select last_insert_id()", Long.class);
+        Integer lastInsertId = this.jdbcTemplate.queryForObject("select last_insert_id()", int.class);
 
         user.setId(lastInsertId);
 
@@ -35,20 +35,22 @@ public class UserDao {
     }
 
     public User selectByEmail(String email, String provider) {
-        String selectByEmailQuery = "select id, nickname,email, password,gender, old ,profile_img_url, introduce,bicycle_type, role, provider, provider_id from user where email = ? and provider = ? and status = 1";
+        String selectByEmailQuery = "select id, nickname,email, password,gender,manner, old ,profile_img_url, introduce,bicycle_type,bicycle_career, role, provider, provider_id from user where email = ? and provider = ? and status = 1";
         Object[] selectByEmailParams = new Object[]{email, provider};
         try {
             return this.jdbcTemplate.queryForObject(selectByEmailQuery,
                     (rs, rowNum) -> new User(
-                            rs.getLong("id"),
+                            rs.getInt("id"),
                             rs.getString("nickname"),
                             rs.getString("email"),
                             rs.getString("password"),
                             rs.getString("gender"),
+                            rs.getDouble("manner"),
                             rs.getInt("old"),
                             rs.getString("profile_img_url"),
                             rs.getString("introduce"),
                             rs.getString("bicycle_type"),
+                            rs.getInt("bicycle_career"),
                             rs.getString("role"),
                             rs.getString("provider"),
                             rs.getString("provider_id")),
@@ -56,6 +58,33 @@ public class UserDao {
         } catch (EmptyResultDataAccessException e) {
             return null;
         }
+    }
+
+    public User selectById(Integer user_id) {
+        String selectByIdQuery = "select id, nickname,email, password,gender,manner, old ,profile_img_url, introduce,bicycle_type,bicycle_career, role, provider, provider_id from user where id = ? and status = 1";
+        return this.jdbcTemplate.queryForObject(selectByIdQuery,
+                (rs, rowNum) -> new User(
+                        rs.getInt("id"),
+                        rs.getString("nickname"),
+                        rs.getString("email"),
+                        rs.getString("password"),
+                        rs.getString("gender"),
+                        rs.getDouble("manner"),
+                        rs.getInt("old"),
+                        rs.getString("profile_img_url"),
+                        rs.getString("introduce"),
+                        rs.getString("bicycle_type"),
+                        rs.getInt("bicycle_career"),
+                        rs.getString("role"),
+                        rs.getString("provider"),
+                        rs.getString("provider_id")),
+                user_id);
+    }
+
+    public int checkId(Integer userId) {
+        String checkIdQuery = "select exists(select nickname from user where id = ? and status = 1)";
+        Integer checkIdParam = userId;
+        return this.jdbcTemplate.queryForObject(checkIdQuery, int.class, checkIdParam);
     }
 
     public int checkEmail(String email, String provider) {
@@ -74,5 +103,24 @@ public class UserDao {
         String checkStatusDisabledQuery = "select exists(select id from user where email = ? and provider = ? and status = 0)";
         Object[] checkStatusDisabledParams = new Object[]{email, provider};
         return this.jdbcTemplate.queryForObject(checkStatusDisabledQuery, int.class, checkStatusDisabledParams);
+    }
+
+    public void updateUserStatus(Integer userId) {
+        String updateStatusQuery = "update user set status = 0 where id = ?";
+        Integer updateStatusParam = userId;
+        this.jdbcTemplate.update(updateStatusQuery, updateStatusParam);
+    }
+
+    public void deleteRefreshToken(Integer userId) {
+        String deleteRefreshTokenQuery = "delete from token where user_id = ?";
+        Integer deleteRefreshTokenParam = userId;
+        this.jdbcTemplate.update(deleteRefreshTokenQuery, deleteRefreshTokenParam);
+    }
+
+    public void deleteByUserStatus(String target_date) {
+        String deleteByUserStatusQuery = "\n" +
+                "delete from user where status = 0 and DATE_FORMAT(DATE_ADD(created_at, INTERVAL 30 DAY), '%Y-%m-%d') = ?";
+
+        this.jdbcTemplate.update(deleteByUserStatusQuery,target_date);
     }
 }

--- a/src/main/java/com/joyride/ms/src/user/UserProvider.java
+++ b/src/main/java/com/joyride/ms/src/user/UserProvider.java
@@ -47,6 +47,25 @@ public class UserProvider {
         }
 
     }
+    @Transactional(readOnly = true)
+    public User retrieveById(Integer userId) throws BaseException {
+        if (checkId(userId) == 0)
+            throw new BaseException(USERS_EMPTY_USER_ID);
+        try {
+            return userDao.selectById(userId);
+        } catch (Exception e) {
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+    @Transactional(readOnly = true)
+    public int checkId(Integer userId) throws BaseException {
+        try {
+            return userDao.checkId(userId);
+        } catch (Exception exception) {
+            log.warn(exception.getMessage());
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
 
     public int checkEmail(String email) throws BaseException {
         return checkEmail(email, "none");

--- a/src/main/java/com/joyride/ms/src/user/UserService.java
+++ b/src/main/java/com/joyride/ms/src/user/UserService.java
@@ -46,6 +46,38 @@ public class UserService {
         }
 
     }
+    @Transactional
+    public void removeUser(Integer userId) throws BaseException {
+        if (userProvider.checkId(userId) == 0)
+            throw new BaseException(USERS_EMPTY_USER_ID);
+        try {
+            userDao.updateUserStatus(userId);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    public void removeRefreshToken(Integer userId) throws BaseException {
+        if (userProvider.checkId(userId) == 0)
+            throw new BaseException(USERS_EMPTY_USER_ID);
+        try {
+            userDao.deleteRefreshToken(userId);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    public void removeUserExpired(String targetDate) throws BaseException {
+        try {
+            userDao.deleteByUserStatus(targetDate);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
     public void createOauth2User(PostSignupOauth2Req postSignupOauth2Req) throws BaseException {
         // provider가 "google" 인지
         if (!userProvider.isProviderCorrect(postSignupOauth2Req.getProvider())) {
@@ -57,7 +89,7 @@ public class UserService {
         }
         String password = passwordEncoder.encode(postSignupOauth2Req.getProviderId());
         User user = new User(nickname, postSignupOauth2Req.getEmail(),
-                password,"",null,"", "ROLE_USER", postSignupOauth2Req.getProvider(), postSignupOauth2Req.getProviderId());
+                password,"",null,"",null, "ROLE_USER", postSignupOauth2Req.getProvider(), postSignupOauth2Req.getProviderId());
         createUser(user, postSignupOauth2Req.isTermsEnable());
     }
 

--- a/src/main/java/com/joyride/ms/src/user/dto/GetUserRes.java
+++ b/src/main/java/com/joyride/ms/src/user/dto/GetUserRes.java
@@ -1,0 +1,20 @@
+package com.joyride.ms.src.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetUserRes {
+    private String profileImgUrl;
+    private String nickname;
+    private String gender;
+    private Double manner;
+    private Integer old;
+    private String introduce;
+    private String bicycleType;
+    private Integer bicycleCareer;
+}
+

--- a/src/main/java/com/joyride/ms/src/user/model/User.java
+++ b/src/main/java/com/joyride/ms/src/user/model/User.java
@@ -9,28 +9,31 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class User {
 
-    private Long id;
+    private Integer id;
     private String nickname;
     private String email;
     private String password;
     private String gender;
+    private Double manner;
     private Integer old;
 
     private String profile_img_url;
     private String introduce;
     private String bicycleType;
+    private Integer bicycleCareer;
     private String role;
     private String provider;
     private String provider_id;
 
 
-    public User(String nickname, String email, String password, String gender,Integer old, String bicycleType, String role, String provider, String provider_id){
+    public User(String nickname, String email, String password, String gender,Integer old, String bicycleType,Integer bicycleCareer, String role, String provider, String provider_id){
         this.nickname = nickname;
         this.email = email;
         this.password = password;
         this.gender = gender;
         this.old = old;
         this.bicycleType = bicycleType;
+        this.bicycleCareer = bicycleCareer;
         this.role = role;
         this.provider = provider;
         this.provider_id = provider_id;


### PR DESCRIPTION
## 관련 이슈

- user api
- pk type

closes #36 

## 작업 내용
- 기존 유저 pk는 sql은 int인데 받는값이 long이어서 integer로 변경
- user api는 (auth제외)권한이 필요해 header에 accesstoken을 넣어줘야합니다.
- swagger에서 헤더에 넣을시 자물쇠를 클릭후 accesstoken값을 복붙해주면 됨
![image](https://user-images.githubusercontent.com/78777461/184882542-c189c44e-dabd-4b26-9aec-66f2882d9fa5.png)

1. 프로필 조회 api - users/:userId
- userId를 pathvariable로 전달시 해당 userId의 유저값 res

2. 유저 삭제 api - users/status
- 유저 탈퇴기능 status를 1 -> 0 으로 바꾸고 1달간 보관한다
- 1달 보관이 지나면 서버에서 자체적으로 삭제 @scheduled

3. 로그아웃 api - users/signout
- 유저의 refreshtoken값을 제거후 success res
- 따라서 클라이언트에서 유저의 쿠키의 accesstoken값과 refreshtoken을 clear해줘야한다
