### PR TITLE
fix: 네트워크 미연결 시 이메일/닉네임 중복 확인 중 에러 발생시킴

### DIFF
--- a/client/src/apis/authAPI.ts
+++ b/client/src/apis/authAPI.ts
@@ -2,7 +2,7 @@ import { joyrideAxios as axios } from './axios';
 import { SetterOrUpdater } from 'recoil';
 
 type SetIsLoggedIn = SetterOrUpdater<boolean>;
-export interface NewUser {
+interface NewUser {
   isTermsEnable: boolean;
   email: string;
   password: string;

--- a/client/src/components/common/CheckBox/index.tsx
+++ b/client/src/components/common/CheckBox/index.tsx
@@ -4,18 +4,18 @@ import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
 interface CheckBoxProps {
+  shape: 'square' | 'circle';
   isChecked: boolean;
-  isCircle?: boolean;
   [key: string]: any;
 }
 
 const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>((props, ref) => {
-  const { isChecked, isCircle, ...others } = props;
+  const { shape, isChecked, ...others } = props;
   return (
     <Checkbox
+      icon={shape === 'circle' ? <RadioButtonUncheckedIcon /> : undefined}
+      checkedIcon={shape === 'circle' ? <CheckCircleIcon /> : undefined}
       checked={isChecked}
-      icon={isCircle && <RadioButtonUncheckedIcon />}
-      checkedIcon={isCircle && <CheckCircleIcon />}
       sx={{
         color: '#e0e0e0',
         padding: 0,

--- a/client/src/components/login/LoginForm/index.tsx
+++ b/client/src/components/login/LoginForm/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { toastMessageState, isLoggedInState } from 'states/atoms';
 import { authAPI } from 'apis/authAPI';
+import { AxiosError } from 'axios';
 import AuthFormInputWithErrorMessageWrapper from 'components/common/AuthFormInputWithErrorMessageWrapper';
 import AuthFormInput from 'components/common/AuthFormInput';
 import ErrorMessage from 'components/common/ErrorMessage';
@@ -26,7 +27,7 @@ function getLoginFailErrorMessage(code: string) {
     case '2112':
       return '비밀번호를 다시 확인해 주세요';
     default:
-      return '로그인 중 에러가 발생했습니다.';
+      return '로그인 중 문제가 발생했습니다.';
   }
 }
 
@@ -61,7 +62,9 @@ const LoginForm = () => {
       // TODO
       // navigate(nextURL || '/');
     } catch (e) {
-      if (e instanceof Error) {
+      if (e instanceof AxiosError) {
+        showToastMessage(getLoginFailErrorMessage(e.message));
+      } else if (e instanceof Error) {
         showToastMessage(getLoginFailErrorMessage(e.message));
       }
     }

--- a/client/src/components/login/LoginForm/index.tsx
+++ b/client/src/components/login/LoginForm/index.tsx
@@ -116,7 +116,12 @@ const LoginForm = () => {
           control={control}
           name="isAuto"
           render={({ field: { value: isChecked, ...others } }) => (
-            <CheckBox isChecked={isChecked} id={cn('auto-login')} {...others} />
+            <CheckBox
+              shape="square"
+              isChecked={isChecked}
+              id={cn('auto-login')}
+              {...others}
+            />
           )}
         />
         <label htmlFor={cn('auto-login')}>자동 로그인</label>

--- a/client/src/components/signup/SignupBasicForm/index.tsx
+++ b/client/src/components/signup/SignupBasicForm/index.tsx
@@ -159,7 +159,7 @@ const SignupBasicForm = () => {
       <div className={cn('btns')}>
         <Button
           type="button"
-          color="white"
+          color="whiteGrey"
           size="md"
           text="이전"
           onClick={decreaseStep}

--- a/client/src/components/signup/SignupBasicForm/index.tsx
+++ b/client/src/components/signup/SignupBasicForm/index.tsx
@@ -1,5 +1,6 @@
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { authAPI } from 'apis/authAPI';
+import { AxiosError } from 'axios';
 import { useSetRecoilState } from 'recoil';
 import { signupFormDataState, useSignupStepControls } from 'routes/Signup';
 import AuthFormInputWithErrorMessageWrapper from 'components/common/AuthFormInputWithErrorMessageWrapper';
@@ -10,7 +11,6 @@ import { getSignupFormErrorMessage } from 'utils/getErrorMessage';
 import Button from 'components/common/Button';
 import styles from './SignupBasicForm.module.scss';
 import classNames from 'classnames/bind';
-import { AxiosError } from 'axios';
 
 const cn = classNames.bind(styles);
 
@@ -43,12 +43,12 @@ const SignupBasicForm = () => {
       await authAPI.checkIfEmailExists(email);
       return true;
     } catch (e) {
-      if (e instanceof Error) {
+      if (e instanceof AxiosError) {
+        setError('email', { type: 'etc' });
+      } else if (e instanceof Error) {
         setError('email', {
           type: e.message === '2017' ? 'duplicated' : 'etc',
         });
-      } else if (e instanceof AxiosError) {
-        setError('email', { type: 'etc' });
       }
       return false;
     }

--- a/client/src/components/signup/SignupDetailForm/index.tsx
+++ b/client/src/components/signup/SignupDetailForm/index.tsx
@@ -64,7 +64,7 @@ const SignupDetailForm = () => {
       bicycleType: '',
       message: '',
     },
-    reValidateMode: 'onBlur',
+    // reValidateMode: 'onBlur',
   });
 
   const showToastMessage = useSetRecoilState(toastMessageState);
@@ -155,8 +155,6 @@ const SignupDetailForm = () => {
         <div className={cn('field')}>
           <label className={cn('label')}>
             <h4 className={cn('title')}>성별</h4>
-            {/* TODO: 디자인 */}
-            <span className={cn('optional')}>(선택 사항)</span>
           </label>
           <ul className={cn('row')}>
             <Controller
@@ -187,7 +185,6 @@ const SignupDetailForm = () => {
         <div className={cn('field')}>
           <label className={cn('label')}>
             <h4 className={cn('title')}>나이</h4>
-            <span className={cn('optional')}>(선택 사항)</span>
           </label>
           <ul className={cn('row')}>
             <Controller
@@ -218,7 +215,6 @@ const SignupDetailForm = () => {
         <div className={cn('field', 'bicycle-type')}>
           <label className={cn('label')}>
             <h4 className={cn('title')}>자전거 종류</h4>
-            <span className={cn('optional')}>(선택 사항)</span>
           </label>
           <Controller
             control={control}
@@ -236,7 +232,7 @@ const SignupDetailForm = () => {
         <div className={cn('field')}>
           <label className={cn('label')}>
             <h4 className={cn('title')}>상태 메세지</h4>
-            <span className={cn('optional')}>(선택 사항)</span>
+            <span className={cn('optional')}>(선택)</span>
           </label>
           <Controller
             control={control}

--- a/client/src/components/signup/SignupDetailForm/index.tsx
+++ b/client/src/components/signup/SignupDetailForm/index.tsx
@@ -269,7 +269,7 @@ const SignupDetailForm = () => {
       <div className={cn('btns')}>
         <Button
           type="button"
-          color="white"
+          color="whiteGrey"
           size="md"
           text="이전"
           onClick={decreaseStep}

--- a/client/src/components/signup/SignupDetailForm/index.tsx
+++ b/client/src/components/signup/SignupDetailForm/index.tsx
@@ -74,12 +74,12 @@ const SignupDetailForm = () => {
       await authAPI.checkIfNicknameExists(nickname);
       return true;
     } catch (e) {
-      if (e instanceof Error) {
+      if (e instanceof AxiosError) {
+        setError('nickname', { type: 'etc' });
+      } else if (e instanceof Error) {
         setError('nickname', {
           type: e.message === '2032' ? 'duplicated' : 'etc',
         });
-      } else if (e instanceof AxiosError) {
-        setError('nickname', { type: 'etc' });
       }
       return false;
     }

--- a/client/src/components/signup/SignupDetailForm/index.tsx
+++ b/client/src/components/signup/SignupDetailForm/index.tsx
@@ -2,7 +2,8 @@ import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { toastMessageState } from 'states/atoms';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { signupFormDataState, useSignupStepControls } from 'routes/Signup';
-import { authAPI, NewUser } from 'apis/authAPI';
+import { authAPI } from 'apis/authAPI';
+import { AxiosError } from 'axios';
 import AuthFormInputWithErrorMessageWrapper from 'components/common/AuthFormInputWithErrorMessageWrapper';
 import AuthFormInput from 'components/common/AuthFormInput';
 import ErrorMessage from 'components/common/ErrorMessage';
@@ -56,6 +57,7 @@ const SignupDetailForm = () => {
     control,
     formState: { isSubmitted, errors },
     handleSubmit,
+    setError,
   } = useForm<SignupDetailForm>({
     defaultValues: {
       nickname: '',
@@ -67,30 +69,25 @@ const SignupDetailForm = () => {
     // reValidateMode: 'onBlur',
   });
 
-  const showToastMessage = useSetRecoilState(toastMessageState);
   const validateNickname = async (nickname: string) => {
     try {
       await authAPI.checkIfNicknameExists(nickname);
       return true;
     } catch (e) {
       if (e instanceof Error) {
-        if (e.message === '2032') return false;
-        showToastMessage('닉네임 중복 확인 중 에러가 발생했습니다');
+        setError('nickname', {
+          type: e.message === '2032' ? 'duplicated' : 'etc',
+        });
+      } else if (e instanceof AxiosError) {
+        setError('nickname', { type: 'etc' });
       }
+      return false;
     }
   };
 
   const [{ email, password }, setSignupFormData] =
     useRecoilState(signupFormDataState);
-  const signup = async (newUser: NewUser) => {
-    try {
-      await authAPI.signup(newUser);
-    } catch (e) {
-      if (e instanceof Error) {
-        showToastMessage('회원가입 중 에러가 발생했습니다');
-      }
-    }
-  };
+  const showToastMessage = useSetRecoilState(toastMessageState);
   const { decreaseStep, increaseStep } = useSignupStepControls();
 
   const onSubmit: SubmitHandler<SignupDetailForm> = async ({
@@ -100,6 +97,9 @@ const SignupDetailForm = () => {
     bicycleType,
     message,
   }) => {
+    const isNicknameValid = await validateNickname(nickname);
+    if (!isNicknameValid) return;
+
     const newUser = {
       isTermsEnable: true,
       email,
@@ -111,9 +111,13 @@ const SignupDetailForm = () => {
       introduce: message || null,
     };
 
-    await signup(newUser);
-    setSignupFormData(data => ({ ...data, nickname }));
-    increaseStep();
+    try {
+      await authAPI.signup(newUser);
+      setSignupFormData(data => ({ ...data, nickname }));
+      increaseStep();
+    } catch (e) {
+      showToastMessage('회원가입 중 문제가 발생했습니다');
+    }
   };
 
   return (
@@ -129,7 +133,6 @@ const SignupDetailForm = () => {
             rules={{
               required: true,
               maxLength: 10,
-              validate: nickname => validateNickname(nickname),
             }}
             render={({ field }) => (
               <AuthFormInputWithErrorMessageWrapper>

--- a/client/src/components/signup/SignupTerms/index.tsx
+++ b/client/src/components/signup/SignupTerms/index.tsx
@@ -51,7 +51,11 @@ const SignupTerms = () => {
   return (
     <form className={cn('form')} onSubmit={handleSubmit}>
       <div className={cn('agree-all', 'term-check')}>
-        <CheckBox isCircle id={cn('all')} onChange={toggleAreAllTermsAgreed} />
+        <CheckBox
+          shape="circle"
+          id={cn('all')}
+          onChange={toggleAreAllTermsAgreed}
+        />
         <label htmlFor={cn('all')}>모두 동의합니다.</label>
       </div>
 
@@ -59,8 +63,8 @@ const SignupTerms = () => {
         <div className={cn('term')}>
           <div className={cn('term-check')}>
             <CheckBox
+              shape="circle"
               isChecked={isServiceTermAgreed}
-              isCircle
               id={cn('first')}
               onChange={toggleIsServiceTermAgreed}
             />
@@ -72,8 +76,8 @@ const SignupTerms = () => {
         <div className={cn('term')}>
           <div className={cn('term-check')}>
             <CheckBox
+              shape="circle"
               isChecked={isPrivacyTermAgreed}
-              isCircle
               id={cn('second')}
               onChange={toggleIsPrivacyTermAgreed}
             />

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,7 +8,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 
 const queryClient = new QueryClient();
 
-const root = createRoot(document.getElementById('root') as HTMLElement);
+const root = createRoot(document.getElementById('root') as HTMLDivElement);
 root.render(
   <React.StrictMode>
     <RecoilRoot>

--- a/client/src/utils/getErrorMessage.ts
+++ b/client/src/utils/getErrorMessage.ts
@@ -54,8 +54,10 @@ export function getSignupFormErrorMessage(
           return '닉네임을 입력하세요';
         case 'maxLength':
           return '10자를 초과하였습니다';
-        case 'validate':
-          return '이미 존재하는 닉네임입니다';
+        case 'duplicated':
+          return '이미 등록된 닉네임입니다';
+        case 'etc':
+          return '닉네임 중복 확인 중 문제가 발생했습니다';
         default:
           throw new Error();
       }

--- a/client/src/utils/getErrorMessage.ts
+++ b/client/src/utils/getErrorMessage.ts
@@ -15,8 +15,10 @@ export function getSignupFormErrorMessage(
           return '이메일을 입력하세요';
         case 'pattern':
           return '이메일 형식이 올바르지 않습니다';
-        case 'validate':
+        case 'duplicated':
           return '이미 등록된 이메일입니다';
+        case 'etc':
+          return '이메일 중복 확인 중 문제가 발생했습니다';
         default:
           throw new Error();
       }


### PR DESCRIPTION
## 관련 이슈

closes #55 

## 작업 내용

기존엔 react hook form 필드의 `rules` prop에 `validate` rule로 비동기 중복 확인 함수(`validateEmail`/`validateNickname`)를 등록한 후, `reValidateMode`를 `onBlur`로 설정함으로써 한 번 form이 제출된 후 이메일/닉네임 입력 필드에 blur 이벤트가 발생하면 곧바로 중복 확인을 진행했었습니다.
**하지만 이처럼 중복 확인 함수가 `validate` rule로 인해 실행되면 중복 에러와 네트워크 미연결 에러를 구분해낼 수 없었습니다.** 따라서 어쩔 수 없이 `validate` rule을 제거하고 form 제출 시 실행되는 **`onSubmit` 콜백 안에서 이메일/닉네임 중복 확인**을 거치도록 했습니다. 이때 에러 발생 시, **중복 에러와 네트워크 미연결 에러를 구분하여 `setError` 콜백을 통해 알맞은 에러 메세지를 보여주도록** 했습니다.

그런데 이렇게 의도적으로 발생시킨 에러는 필드에 새 값이 입력되면 바로 reset 된다는 문제점이 있습니다. 이는 react hook form의 한계로, 기능상 문제는 없지만 추후 디벨롭 시 다른 라이브러리로 교체하거나 라이브러리를 사용하지 않을지 고민 중입니다. 새 값 입력 시 바로 에러 메세지가 사라지기에, 새로운 값은 중복되지 않는구나 하고 유저가 헷갈릴 수도 있기 때문입니다.

또한 기존엔 `onBlur` 였던 `reValidateMode`를 해제함으로써, 한 번 form이 제출된 후 이메일/닉네임 필드를 제외하고는 각 필드에 change 이벤트 발생 시 필드 유효성 검사가 진행될 수 있도록 변경했습니다. (UX 개선)

## Test scenario or New setup

서버 port를 닫거나 네트워크 연결을 해제한 채로, 회원가입 2단계의 `다음` 버튼 or 3단계의 `회원가입하기` 버튼 클릭
