### PR TITLE
Feature/코스 디테일 조회 api 개발 #74

### DIFF
--- a/src/main/java/com/joyride/ms/src/course/CourseController.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseController.java
@@ -16,7 +16,6 @@ public class CourseController {
     private final CourseService courseService;
 
     //일단은 이 URI를 거쳐서만 들어간다고 생각하고 코드 작성
-    @ResponseBody
     @GetMapping("")
     public BaseResponse<List<GetCourseListRes>> getCourseList(){
         try{
@@ -28,7 +27,6 @@ public class CourseController {
     }
 
     // 리뷰작성 api
-    @ResponseBody
     @PostMapping("/review")
     public BaseResponse<PostCourseReviewRes> PostCourseReview(@RequestBody PostCourseReviewReq postCourseReviewReq){
 
@@ -42,7 +40,6 @@ public class CourseController {
     }
 
     // 리뷰 조회 api
-    @ResponseBody
     @GetMapping("/review/{course_id}")
     public BaseResponse<List<GetCourseReviewRes>> PostCourseReview(@PathVariable("course_id") int course_id){
         try{
@@ -55,9 +52,8 @@ public class CourseController {
     }
 
     // 리뷰 삭제 api
-    @ResponseBody
-    @PatchMapping("/review/{id}/staus")
-    public BaseResponse<PatchCourseReviewRes> PatchCourseReviewStatus(@PathVariable("id") int courseReview_id){
+    @DeleteMapping("/review/{id}")
+    public BaseResponse<PatchCourseReviewRes> PatchCourseReview(@PathVariable("id") int courseReview_id){
         try{
             // 유저 확인 로직 필요
             PatchCourseReviewRes patchCourseReviewRes = courseService.removeCourseReview(courseReview_id);
@@ -66,9 +62,4 @@ public class CourseController {
             return new BaseResponse<>((exception.getStatus()));
         }
     }
-
-
-
-
-
 }

--- a/src/main/java/com/joyride/ms/src/course/CourseController.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseController.java
@@ -81,5 +81,19 @@ public class CourseController {
         }
     }
 
+    //리뷰 종아요 취소 api
+    @DeleteMapping("/like/{courseLike_id}")
+    public BaseResponse<DeleteCourseLikeRes> PatchCourseReviewStatus(@PathVariable("courseLike_id") int courseLike_id){
+        try{
+            // 유저 확인 로직 필요
+            DeleteCourseLikeRes deleteCourseReviewRes = courseService.removeCourseLike(courseLike_id);
+            return new BaseResponse<>(deleteCourseReviewRes);
+        } catch(BaseException exception){
+            return new BaseResponse<>((exception.getStatus()));
+        }
+    }
+
+
+
 
 }

--- a/src/main/java/com/joyride/ms/src/course/CourseController.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseController.java
@@ -53,13 +53,33 @@ public class CourseController {
 
     // 리뷰 삭제 api
     @DeleteMapping("/review/{id}")
-    public BaseResponse<PatchCourseReviewRes> PatchCourseReview(@PathVariable("id") int courseReview_id){
+    public BaseResponse<DeleteCourseReviewRes> PatchCourseReview(@PathVariable("id") int courseReview_id){
         try{
             // 유저 확인 로직 필요
-            PatchCourseReviewRes patchCourseReviewRes = courseService.removeCourseReview(courseReview_id);
-            return new BaseResponse<>(patchCourseReviewRes);
+            DeleteCourseReviewRes deleteCourseReviewRes = courseService.removeCourseReview(courseReview_id);
+            return new BaseResponse<>(deleteCourseReviewRes);
         } catch(BaseException exception){
             return new BaseResponse<>((exception.getStatus()));
         }
     }
+
+    /**
+     * 좋아요 api
+     */
+    // 리뷰 종아요 api
+    // 요청: 좋아요할 코스의 아이디와 좋아요하는 유저 아이디 필요
+    // @PathVariable로 하는게 맞을까? RequestBody로 하는게 맞을까?
+    // 응답:
+    @PostMapping("/like/{user_id}/{course_id}")
+    public BaseResponse<PostCourseLikeRes> PostCourseLike(@PathVariable("user_id") int user_id, @PathVariable("course_id") int course_id){
+        try{
+            // 유저 확인 로직 필요
+            PostCourseLikeRes postCourseLikeRes = courseService.createCourseLike(user_id, course_id);
+            return new BaseResponse<>(postCourseLikeRes);
+        } catch(BaseException exception){
+            return new BaseResponse<>((exception.getStatus()));
+        }
+    }
+
+
 }

--- a/src/main/java/com/joyride/ms/src/course/CourseController.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseController.java
@@ -26,6 +26,17 @@ public class CourseController {
         }
     }
 
+    // 코스 디테일 조회 api
+    @GetMapping("/{course_id}")
+    public BaseResponse<GetCourseRes> getCourse(@PathVariable("course_id") int course_id){
+        try{
+            GetCourseRes getCourseRes = courseProvider.retrieveCourse(course_id);
+            return new BaseResponse<>(getCourseRes);
+        } catch(BaseException exception){
+            return new BaseResponse<>((exception.getStatus()));
+        }
+    }
+
     // 리뷰작성 api
     @PostMapping("/review")
     public BaseResponse<PostCourseReviewRes> PostCourseReview(@RequestBody PostCourseReviewReq postCourseReviewReq){

--- a/src/main/java/com/joyride/ms/src/course/CourseDao.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseDao.java
@@ -83,7 +83,7 @@ public class CourseDao {
                 "       CR.created_at, CR.updated_at from coursereview CR\n" +
                 "                              INNER join user U\n" +
                 "                                    on CR.user_id = U.id\n" +
-                "    where course_id=? and status = 1";
+                "    where course_id=?";
 
 
         int selectCourseReviewParams = course_id;
@@ -112,14 +112,14 @@ public class CourseDao {
     // 코스 리뷰 삭제
     public void deleteByCourseReviewId(int courseReview_id){
 
-        String deleteByCourseReviewIdQuery = "update coursereview set status = 0 where id = ?";
+        String deleteByCourseReviewIdQuery = "delete from coursereview where id = ?";
         int deleteByCourseReviewIdParams = courseReview_id;
 
         this.jdbcTemplate.update(deleteByCourseReviewIdQuery, deleteByCourseReviewIdParams);
     }
 
     public int existsCourseReview(int courseReview_id) {
-        String existsCourseReviewQuery = "select exists(select id from coursereview where id = ? and status = 1)";
+        String existsCourseReviewQuery = "select exists(select id from coursereview where id = ?)";
         int existsCourseReviewParams = courseReview_id;
         return this.jdbcTemplate.queryForObject(existsCourseReviewQuery,
                 int.class,

--- a/src/main/java/com/joyride/ms/src/course/CourseDao.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseDao.java
@@ -54,6 +54,41 @@ public class CourseDao {
         this.jdbcTemplate.update(createCourseListQuery, createCourseListParams);
     }
 
+    // 코스 디테일 정보
+    public GetCourseRes selectCourse(int course_id){
+        String getCourseQuery = "select id,title,course_img_url,content,summary," +
+                "tour_point, travelerinfo, distance, difficulty, sigun, required_at, created_at, updated_at " +
+                "from course where id = course_id";
+
+        int getCourseParams = course_id;
+        //db정보 가져오기
+        return this.jdbcTemplate.queryForObject(getCourseQuery,
+                (rs,rowNum) -> GetCourseRes.createGetCourseRes(
+                        rs.getInt("id"),
+                        rs.getString("title"),
+                        rs.getString("course_img_url"),
+                        rs.getString("content"),
+                        rs.getString("summary"),
+                        rs.getString("tour_point"),
+                        rs.getString("travelerinfo"),
+                        rs.getDouble("distance"),
+                        rs.getInt("difficulty"),
+                        rs.getString("sigun"),
+                        rs.getDouble("required_at"),
+                        rs.getString("created_at"),
+                        rs.getString("updated_at")
+                ),
+                getCourseParams);
+    }
+    
+    //코스 좋아요 유저 아이디 조회
+    public int selectUserIdByCourseId(int course_id) {
+        String selectUserIdByCourseIdQuery = "select user_id from courselike where course_id = course_id";
+
+        int selectUserIdByCourseIdParams = course_id;
+        //db정보 가져오기
+        return this.jdbcTemplate.queryForObject(selectUserIdByCourseIdQuery, Integer.class, selectUserIdByCourseIdParams);
+    }
     // 리뷰 생성 Dao
     public int insertCourseReview(PostCourseReviewReq postCourseReviewReq, double totalRate){
 

--- a/src/main/java/com/joyride/ms/src/course/CourseDao.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseDao.java
@@ -50,11 +50,11 @@ public class CourseDao {
         String createCourseListQuery = "insert into course (title, course_img_url, content, summary, tour_point, travelerinfo, distance, " +
                 "difficulty, sigun, required_at, brdDiv) VALUES (?,?,?,?,?,?,?,?,?,?,?)";
 
-        Object[] createUserParams = new Object[]{courseInfo.getCrsKorNm(), courseInfo.getImage(),
+        Object[] createCourseListParams = new Object[]{courseInfo.getCrsKorNm(), courseInfo.getImage(),
                 courseInfo.getCrsContents(), courseInfo.getCrsSummary(), courseInfo.getCrsTourInfo(), courseInfo.getTravelerinfo(),
                 courseInfo.getCrsDstnc(), courseInfo.getCrsLevel(), courseInfo.getSigun(),
                 courseInfo.getRequired_at(), courseInfo.getBrdDiv()};
-        this.jdbcTemplate.update(createCourseListQuery, createUserParams);
+        this.jdbcTemplate.update(createCourseListQuery, createCourseListParams);
     }
 
     // 리뷰 생성 Dao
@@ -126,5 +126,17 @@ public class CourseDao {
                 existsCourseReviewParams);
     }
 
+    /**
+     * 코스 좋아요
+     */
+    public int insertCourseLike(int user_id, int course_id){
 
+        String createCourseLikeQuery = "insert into courselike (user_id, course_id) VALUES (?,?)";
+
+        Object[] createCourseLikeParams = new Object[]{user_id, course_id};
+        this.jdbcTemplate.update(createCourseLikeQuery, createCourseLikeParams);
+
+        String lastInsertIdQuery = "select last_insert_id()";
+        return this.jdbcTemplate.queryForObject(lastInsertIdQuery,int.class);
+    }
 }

--- a/src/main/java/com/joyride/ms/src/course/CourseDao.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseDao.java
@@ -139,4 +139,23 @@ public class CourseDao {
         String lastInsertIdQuery = "select last_insert_id()";
         return this.jdbcTemplate.queryForObject(lastInsertIdQuery,int.class);
     }
+
+    //좋아요 삭제
+
+    public void deleteByCourseLikeId(int courseLike_id){
+
+        String deleteByCourseLikeIdQuery = "delete from courselike where id = ?";
+        int deleteByCourseLikeIdParams = courseLike_id;
+
+        this.jdbcTemplate.update(deleteByCourseLikeIdQuery, deleteByCourseLikeIdParams);
+    }
+
+    public int existsCourseLike(int courseLike_id) {
+        String existsCourseLikeQuery = "select exists(select id from courselike where id = ?)";
+        int existsCourseLikeParams = courseLike_id;
+        return this.jdbcTemplate.queryForObject(existsCourseLikeQuery,
+                int.class,
+                existsCourseLikeParams);
+    }
+
 }

--- a/src/main/java/com/joyride/ms/src/course/CourseDao.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseDao.java
@@ -81,12 +81,14 @@ public class CourseDao {
     }
     
     //코스 좋아요 유저 아이디 조회
-    public int selectUserIdByCourseId(int course_id) {
+    public List<Integer> selectUserIdByCourseId(int course_id) {
         String selectUserIdByCourseIdQuery = "select user_id from courselike where course_id = ?";
 
         int selectUserIdByCourseIdParams = course_id;
         //db정보 가져오기
-        return this.jdbcTemplate.queryForObject(selectUserIdByCourseIdQuery, Integer.class, selectUserIdByCourseIdParams);
+        return this.jdbcTemplate.query(selectUserIdByCourseIdQuery,
+                (rs,rowNum) -> rs.getInt("user_id"),
+                selectUserIdByCourseIdParams);
     }
     // 리뷰 생성 Dao
     public int insertCourseReview(PostCourseReviewReq postCourseReviewReq, double totalRate){

--- a/src/main/java/com/joyride/ms/src/course/CourseDao.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseDao.java
@@ -58,7 +58,7 @@ public class CourseDao {
     public GetCourseRes selectCourse(int course_id){
         String getCourseQuery = "select id,title,course_img_url,content,summary," +
                 "tour_point, travelerinfo, distance, difficulty, sigun, required_at, created_at, updated_at " +
-                "from course where id = course_id";
+                "from course where id = ?";
 
         int getCourseParams = course_id;
         //db정보 가져오기
@@ -77,13 +77,12 @@ public class CourseDao {
                         rs.getDouble("required_at"),
                         rs.getString("created_at"),
                         rs.getString("updated_at")
-                ),
-                getCourseParams);
+                ), getCourseParams);
     }
     
     //코스 좋아요 유저 아이디 조회
     public int selectUserIdByCourseId(int course_id) {
-        String selectUserIdByCourseIdQuery = "select user_id from courselike where course_id = course_id";
+        String selectUserIdByCourseIdQuery = "select user_id from courselike where course_id = ?";
 
         int selectUserIdByCourseIdParams = course_id;
         //db정보 가져오기

--- a/src/main/java/com/joyride/ms/src/course/CourseDao.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseDao.java
@@ -1,9 +1,6 @@
 package com.joyride.ms.src.course;
 
-import com.joyride.ms.src.course.model.CourseInfo;
-import com.joyride.ms.src.course.model.GetCourseListRes;
-import com.joyride.ms.src.course.model.GetCourseReviewRes;
-import com.joyride.ms.src.course.model.PostCourseReviewReq;
+import com.joyride.ms.src.course.model.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/joyride/ms/src/course/CourseProvider.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseProvider.java
@@ -1,6 +1,7 @@
 package com.joyride.ms.src.course;
 
 import com.joyride.ms.src.course.model.GetCourseListRes;
+import com.joyride.ms.src.course.model.GetCourseRes;
 import com.joyride.ms.src.course.model.GetCourseReviewRes;
 import com.joyride.ms.util.BaseException;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class CourseProvider {
             throw new BaseException(DATABASE_ERROR);
         }
     }
+
 
 
 }

--- a/src/main/java/com/joyride/ms/src/course/CourseProvider.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseProvider.java
@@ -6,6 +6,7 @@ import com.joyride.ms.src.course.model.GetCourseReviewRes;
 import com.joyride.ms.util.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -13,6 +14,7 @@ import static com.joyride.ms.util.BaseResponseStatus.DATABASE_ERROR;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CourseProvider {
 
     private final CourseDao courseDao;
@@ -40,6 +42,24 @@ public class CourseProvider {
         }
     }
 
+    public GetCourseRes retrieveCourse(int course_id) throws BaseException {
+        try{
+            GetCourseRes getCourseRes = courseDao.selectCourse(course_id);
 
+            // 좋아요한 userId
+            int userId = courseDao.selectUserIdByCourseId(course_id);
+            getCourseRes.setUserId(userId);
+
+            // 코스 리뷰들
+            List<GetCourseReviewRes> getCourseReviewRes = courseDao.selectCourseReviewByCourseId(course_id);
+            getCourseRes.setGetCourseReviewRes(getCourseReviewRes);
+
+            return getCourseRes;
+        }
+        catch (Exception exception) {
+            exception.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
 
 }

--- a/src/main/java/com/joyride/ms/src/course/CourseProvider.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseProvider.java
@@ -47,8 +47,8 @@ public class CourseProvider {
             GetCourseRes getCourseRes = courseDao.selectCourse(course_id);
 
             // 좋아요한 userId
-            int userId = courseDao.selectUserIdByCourseId(course_id);
-            getCourseRes.setUserId(userId);
+            List<Integer> userIdList = courseDao.selectUserIdByCourseId(course_id);
+            getCourseRes.setUserIdList(userIdList);
 
             // 코스 리뷰들
             List<GetCourseReviewRes> getCourseReviewRes = courseDao.selectCourseReviewByCourseId(course_id);

--- a/src/main/java/com/joyride/ms/src/course/CourseService.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseService.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static com.joyride.ms.util.BaseResponseStatus.*;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class CourseService {
 
@@ -28,7 +28,6 @@ public class CourseService {
     private final CourseDao courseDao;
     private final CourseProvider courseProvider;
 
-    @Transactional
     public List<GetCourseListRes> createCourseList() throws BaseException {
         try {
             int check = courseDao.existsCourse("고락산 둘레길");
@@ -102,7 +101,6 @@ public class CourseService {
     }
 
     // 리뷰작성 service
-    @Transactional
     public PostCourseReviewRes createCourseReview(PostCourseReviewReq postCourseReviewReq) throws BaseException {
 
         try{
@@ -117,6 +115,7 @@ public class CourseService {
     }
 
     //totalRate 계산 메소드
+    @Transactional(readOnly = true)
     public Double calculateTotalRate(PostCourseReviewReq postCourseReviewReq) throws BaseException {
         try{
             double sum = postCourseReviewReq.getAccessibility_rate() + postCourseReviewReq.getFacilities_rate() +
@@ -131,7 +130,6 @@ public class CourseService {
     }
 
     //리뷰 삭제 api
-    @Transactional
     public DeleteCourseReviewRes removeCourseReview(int courseReview_id) throws BaseException {
 
         // 유저확인 로직 필요
@@ -153,7 +151,6 @@ public class CourseService {
      */
 
     //코스 좋아요 생성
-    @Transactional
     public PostCourseLikeRes createCourseLike(int user_id, int course_id) throws BaseException {
 
         // 유저확인 로직 필요
@@ -167,7 +164,6 @@ public class CourseService {
     }
 
     //코스 좋아요 삭제
-    @Transactional
     public DeleteCourseLikeRes removeCourseLike(int courseLike_id) throws BaseException {
 
         // 유저확인 로직 필요

--- a/src/main/java/com/joyride/ms/src/course/CourseService.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseService.java
@@ -16,8 +16,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.joyride.ms.util.BaseResponseStatus.COURSE_REVIEW_NOT_EXISTS;
-import static com.joyride.ms.util.BaseResponseStatus.DATABASE_ERROR;
+import static com.joyride.ms.util.BaseResponseStatus.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -133,7 +132,7 @@ public class CourseService {
 
     //리뷰 삭제 api
     @Transactional
-    public PatchCourseReviewRes removeCourseReview(int courseReview_id) throws BaseException {
+    public DeleteCourseReviewRes removeCourseReview(int courseReview_id) throws BaseException {
 
         // 유저확인 로직 필요
         int existsCourseReview = courseDao.existsCourseReview(courseReview_id);
@@ -143,11 +142,26 @@ public class CourseService {
         try{
            courseDao.deleteByCourseReviewId(courseReview_id);
             String message = "리뷰 삭제에 성공했습니다.";
-            return new PatchCourseReviewRes(message);
+            return new DeleteCourseReviewRes(message);
         } catch (Exception exception) {
             throw new BaseException(DATABASE_ERROR);
         }
     }
 
+    /**
+     * 코스 좋아요
+     */
+    @Transactional
+    public PostCourseLikeRes createCourseLike(int user_id, int course_id) throws BaseException {
+
+        // 유저확인 로직 필요
+        try{
+            int likeId = courseDao.insertCourseLike(user_id, course_id);
+            return new PostCourseLikeRes(likeId);
+        } catch (Exception exception) {
+            exception.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
 }
 

--- a/src/main/java/com/joyride/ms/src/course/CourseService.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseService.java
@@ -151,6 +151,8 @@ public class CourseService {
     /**
      * 코스 좋아요
      */
+
+    //코스 좋아요 생성
     @Transactional
     public PostCourseLikeRes createCourseLike(int user_id, int course_id) throws BaseException {
 
@@ -163,5 +165,24 @@ public class CourseService {
             throw new BaseException(DATABASE_ERROR);
         }
     }
+
+    //코스 좋아요 삭제
+    @Transactional
+    public DeleteCourseLikeRes removeCourseLike(int courseLike_id) throws BaseException {
+
+        // 유저확인 로직 필요
+        int existsCourseLike = courseDao.existsCourseLike(courseLike_id);
+        if (existsCourseLike == 0) {
+            throw new BaseException(COURSE_LIKE_NOT_EXISTS);
+        }
+        try{
+            courseDao.deleteByCourseLikeId(courseLike_id);
+            String message = "좋아요 삭제에 성공했습니다.";
+            return new DeleteCourseLikeRes(message);
+        } catch (Exception exception) {
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
 }
 

--- a/src/main/java/com/joyride/ms/src/course/model/DeleteCourseLikeRes.java
+++ b/src/main/java/com/joyride/ms/src/course/model/DeleteCourseLikeRes.java
@@ -1,0 +1,13 @@
+package com.joyride.ms.src.course.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeleteCourseLikeRes {
+
+    private String message;
+
+}

--- a/src/main/java/com/joyride/ms/src/course/model/DeleteCourseReviewRes.java
+++ b/src/main/java/com/joyride/ms/src/course/model/DeleteCourseReviewRes.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PatchCourseReviewRes {
+public class DeleteCourseReviewRes {
 
     private String message;
 

--- a/src/main/java/com/joyride/ms/src/course/model/GetCourseLikeRes.java
+++ b/src/main/java/com/joyride/ms/src/course/model/GetCourseLikeRes.java
@@ -1,0 +1,12 @@
+package com.joyride.ms.src.course.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetCourseLikeRes {
+
+    int count;
+}

--- a/src/main/java/com/joyride/ms/src/course/model/GetCourseRes.java
+++ b/src/main/java/com/joyride/ms/src/course/model/GetCourseRes.java
@@ -1,0 +1,88 @@
+package com.joyride.ms.src.course.model;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetCourseRes {
+
+    //응답 값
+    private int id;
+
+    //title
+    private String crsKorNm;
+
+    //course_img_url
+    private String image;
+
+    private String crsContents;
+
+    private String crsSummary;
+
+    //tour_point 둘 중 뭐지?
+    private String crsTourInfo;
+
+    //    @Lob
+    private String travelerinfo;
+
+    //total_rate
+    //private double total_rate;
+
+    //거리 distance
+    private double crsDstnc;
+
+    //difficulty
+    private int crsLevel;
+
+    //시군
+    private String sigun;
+
+    //소요시간
+    private double required_at;
+
+    //LocalDateTime?
+    private String created_at;
+
+    private String updated_at;
+
+    // 이 클래스를 확장해서 디테일에서 보여줄 부분들 추가
+
+    // 좋아요 표시용
+    private int userId;
+
+    // 리뷰
+
+    private List<GetCourseReviewRes> getCourseReviewRes;
+
+    //==생성 메서드==//
+    //GetCourseListRes 생성 메서드 이용
+    public static GetCourseRes createGetCourseRes(int id, String crsKorNm, String image, String crsContents, String crsSummary, String crsTourInfo,
+                                                           String travelerinfo, double crsDstnc, int crsLevel, String sigun,
+                                                           double required_at, String created_at, String updated_at) {
+        GetCourseRes getCourseRes = new GetCourseRes();
+        getCourseRes.setId(id);
+        getCourseRes.setCrsKorNm(crsKorNm);
+        getCourseRes.setImage(image);
+        //courseInfo.setTotal_rate(total_rate);
+        getCourseRes.setCrsContents(crsContents);
+        getCourseRes.setCrsSummary(crsSummary);
+        getCourseRes.setCrsTourInfo(crsTourInfo);
+        getCourseRes.setTravelerinfo(travelerinfo);
+//        getCourseRes.setTotal_rate(total_rate);
+        getCourseRes.setCrsDstnc(crsDstnc);
+//        getCourseRes.setCrsTotlRqrmHour(crsTotlRqrmHour);
+        getCourseRes.setCrsLevel(crsLevel);
+        getCourseRes.setSigun(sigun);
+        getCourseRes.setRequired_at(required_at);
+        getCourseRes.setCreated_at(created_at);
+        getCourseRes.setUpdated_at(updated_at);
+
+
+        return getCourseRes;
+    }
+
+}

--- a/src/main/java/com/joyride/ms/src/course/model/GetCourseRes.java
+++ b/src/main/java/com/joyride/ms/src/course/model/GetCourseRes.java
@@ -51,8 +51,8 @@ public class GetCourseRes {
 
     // 이 클래스를 확장해서 디테일에서 보여줄 부분들 추가
 
-    // 좋아요 표시용
-    private int userId;
+    // 좋아요 누른 유저들
+    private List<Integer> userIdList;
 
     // 리뷰
 

--- a/src/main/java/com/joyride/ms/src/course/model/PostCourseLikeRes.java
+++ b/src/main/java/com/joyride/ms/src/course/model/PostCourseLikeRes.java
@@ -1,0 +1,11 @@
+package com.joyride.ms.src.course.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostCourseLikeRes {
+    private int id;
+}

--- a/src/main/java/com/joyride/ms/util/BaseResponseStatus.java
+++ b/src/main/java/com/joyride/ms/util/BaseResponseStatus.java
@@ -60,6 +60,7 @@ public enum BaseResponseStatus {
 
     //500
    COURSE_REVIEW_NOT_EXISTS(false, 2500, "해당 코스리뷰가 없습니다."),
+    COURSE_LIKE_NOT_EXISTS(false, 2501, "코스 좋아요가 없습니다."),
 
     /**
      * 3000 : Response 오류


### PR DESCRIPTION
## 관련 이슈

closes #74 

## 작업 내용
코스 디테일 조회 api 개발
프론트로 전달 내용:
1. 코스 기본 정보들
2. 각 글에 달린 리뷰들(리스트)
-> 유저가 리뷰 필터를 선택하면 각 필터(ex 경관)에 맞는 정보만 조회하는 api를 따로 개발하면 프론트에서 해당 디테일 페이지에서 리뷰만 필터에 따로 바뀌도록 이용할 수 있나요? 아니면 지금 제가 만든 디테일 조회 api 자체에서 필터링도 가능하도록 해야하는 건가요? 
4. 코스에 좋아요를 누른 유저들 아이디(리스트) 
-> 해당 코스를 좋아요 한 유저에게는 하트가 빨간색으로 보여야 해서 코스에 좋아요를 누른 유저들 아이디도 함께 조회하도록 했는데 이 정보가 필요할까요? 아니면 userId도 api 요청시에 받아서 해당 userId로 코스 좋아요를 조회해서 해당 코스 좋아요 유무를 판단하는 방식이 더 좋을까요? 
그냥 프론트에서 하트 색칠 여부를 보여줄 때는 이러한 정보 자체가 필요가 없을까요?  
5. 관련 모임은 모임 작업 완료되고 같이 조회하면 될 것 같습니다. 
## Test scenario or New setup
