### PR TITLE
유저api 수정 및 accessToken 만료시간 변경

### DIFF
--- a/src/main/java/com/joyride/ms/src/auth/AuthController.java
+++ b/src/main/java/com/joyride/ms/src/auth/AuthController.java
@@ -110,7 +110,7 @@ public class AuthController {
         String accessToken = token.getAccessToken();
         String refreshToken = token.getRefreshToken();
 
-        PostSigninRes postSigninRes = new PostSigninRes(accessToken);
+        PostSigninRes postSigninRes = new PostSigninRes(accessToken,userId);
         authService.registerRefreshToken(userId, refreshToken);
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken",refreshToken)
@@ -154,7 +154,7 @@ public class AuthController {
         Token token = jwtTokenProvider.createToken(userId);
         String accessToken = token.getAccessToken();
         String refreshToken = token.getRefreshToken();
-        PostAutoSigninRes postAutoSigninRes = new PostAutoSigninRes(accessToken);
+        PostAutoSigninRes postAutoSigninRes = new PostAutoSigninRes(accessToken,userId);
 
         authService.registerRefreshToken(userId, refreshToken);
 
@@ -186,8 +186,7 @@ public class AuthController {
         }
 
         try {
-            String newAccessToken = authService.createAccess(refreshToken);
-            PostAccessRes postAccessRes = new PostAccessRes(newAccessToken);
+            PostAccessRes postAccessRes = authService.createAccess(refreshToken);
             return new BaseResponse<>(postAccessRes);
         } catch (BaseException exception) {
             return new BaseResponse<>(exception.getStatus());

--- a/src/main/java/com/joyride/ms/src/auth/AuthService.java
+++ b/src/main/java/com/joyride/ms/src/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.joyride.ms.src.auth;
 
+import com.joyride.ms.src.auth.dto.PostAccessRes;
 import com.joyride.ms.src.jwt.JwtTokenProvider;
 import com.joyride.ms.util.BaseException;
 import com.joyride.ms.util.BaseResponseStatus;
@@ -28,13 +29,15 @@ public class AuthService {
         return userId;
     }
     @Transactional
-    public String createAccess(String refreshToken) throws BaseException {
+    public PostAccessRes createAccess(String refreshToken) throws BaseException {
 
         Integer userId = Integer.parseInt(jwtTokenProvider.getUseridFromRef(refreshToken));
 
         String newAccessToken = jwtTokenProvider.createAccessToken(userId);
+        PostAccessRes postAccessRes = new PostAccessRes(newAccessToken,userId);
 
-        return newAccessToken;
+
+        return postAccessRes;
 
     }
 }

--- a/src/main/java/com/joyride/ms/src/auth/dto/PostAccessRes.java
+++ b/src/main/java/com/joyride/ms/src/auth/dto/PostAccessRes.java
@@ -7,4 +7,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class PostAccessRes {
     private final String accessToken;
+    private Integer userId;
 }

--- a/src/main/java/com/joyride/ms/src/auth/dto/PostAutoSigninRes.java
+++ b/src/main/java/com/joyride/ms/src/auth/dto/PostAutoSigninRes.java
@@ -7,4 +7,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class PostAutoSigninRes {
     private String accessToken;
+    private Integer userId;
 }

--- a/src/main/java/com/joyride/ms/src/auth/dto/PostSigninRes.java
+++ b/src/main/java/com/joyride/ms/src/auth/dto/PostSigninRes.java
@@ -8,4 +8,5 @@ import lombok.Data;
 public class PostSigninRes {
 
     private String accessToken;
+    private Integer userId;
 }

--- a/src/main/java/com/joyride/ms/src/jwt/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/joyride/ms/src/jwt/handler/OAuth2SuccessHandler.java
@@ -31,7 +31,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.setCharacterEncoding("utf-8");
 
         PrincipalDetails oAuth2User = (PrincipalDetails) authentication.getPrincipal();
-        System.out.println(oAuth2User.getUser().getId());
         Token token = jwtTokenProvider.createToken(oAuth2User.getUser().getId());
         String refreshToken = token.getRefreshToken();
 

--- a/src/main/java/com/joyride/ms/src/user/UserController.java
+++ b/src/main/java/com/joyride/ms/src/user/UserController.java
@@ -137,7 +137,7 @@ public class UserController {
             Integer userId = Integer.parseInt(request.getAttribute("user_id").toString());
 
             String profile_img_fileKey = userProvider.retrieveById(userId).getProfile_img_url();
-            if (!profile_img_fileKey.equals("https://bucket-joyride.s3.ap-northeast-2.amazonaws.com/profile/default-img.png"))
+            if (!profile_img_fileKey.equals("https://bucket-joyride.s3.ap-northeast-2.amazonaws.com/profile/default-img.svg"))
                 awsS3Service.fileDelete(profile_img_fileKey.substring(55));
 
             String dirName = "profile/info/" + userId + "/profile-img";
@@ -161,7 +161,7 @@ public class UserController {
 
         try {
             String filekey = userProvider.retrieveById(userId).getProfile_img_url();
-            if (filekey.equals("https://bucket-joyride.s3.ap-northeast-2.amazonaws.com/profile/default-img.png"))
+            if (filekey.equals("https://bucket-joyride.s3.ap-northeast-2.amazonaws.com/profile/default-img.svg"))
                 return new BaseResponse<>("삭제에 성공하였습니다.");
 
             filekey = userProvider.retrieveById(userId).getProfile_img_url().substring(55);


### PR DESCRIPTION
## 관련 이슈

closes #98 

## 작업 내용
- auth api 변경 - 로그인, 자동로그인, jwt 발급시 userId res
- 유저 db 정리
- accessToken만료시간 20분으로 변경 - 노션에 secret.yml 참고 바람

