### PR TITLE
feat: 모임 리스트 페이지네이션/필터 API 연결/모임 관련 부분 보완

### DIFF
--- a/client/src/apis/authAPI.ts
+++ b/client/src/apis/authAPI.ts
@@ -45,7 +45,7 @@ export const authAPI = (() => {
   ) => {
     const {
       data: { code, result },
-    } = await axios.post(`/auth/signin${isAuto ? '/auto' : ''}`, {
+    } = await axios.post('/auth/signin' + (isAuto ? '/auto' : ''), {
       email,
       password,
     });

--- a/client/src/components/common/DateTimePicker/index.tsx
+++ b/client/src/components/common/DateTimePicker/index.tsx
@@ -126,7 +126,7 @@ const DateTimePicker = forwardRef<DatePicker, DateTimePickerProps>(
           </header>
         )}
         placeholderText={placeholder}
-        popperPlacement="auto"
+        popperPlacement="bottom"
         fixedHeight
         closeOnScroll
         showPopperArrow={false}

--- a/client/src/components/common/Modal/index.tsx
+++ b/client/src/components/common/Modal/index.tsx
@@ -7,7 +7,7 @@ const Modal = () => {
   const close = useResetRecoilState(modalContentState);
   return (
     <Dialog
-      open={Boolean(content)}
+      open={!!content}
       BackdropProps={{ style: { background: 'rgba(0,0,0,0.2)' } }}
       PaperProps={{
         style: {

--- a/client/src/components/common/NoResults/NoResults.module.scss
+++ b/client/src/components/common/NoResults/NoResults.module.scss
@@ -1,0 +1,17 @@
+@use '../../../styles/variables.scss' as *;
+
+.wrapper {
+  margin-top: 6rem;
+  text-align: center;
+
+  & > svg {
+    font-size: 6rem;
+    color: $color-main;
+  }
+}
+
+.title {
+  font-size: 2.4rem;
+  font-weight: 700;
+  margin: 2.5rem 0 2rem 0;
+}

--- a/client/src/components/common/NoResults/index.tsx
+++ b/client/src/components/common/NoResults/index.tsx
@@ -1,0 +1,14 @@
+import styles from './NoResults.module.scss';
+import classNames from 'classnames/bind';
+import { BsExclamationCircle } from 'react-icons/bs';
+
+const cn = classNames.bind(styles);
+
+const NoResults = () => (
+  <div className={cn('wrapper')}>
+    <BsExclamationCircle />
+    <h1 className={cn('title')}>검색 결과가 없습니다.</h1>
+  </div>
+);
+
+export default NoResults;

--- a/client/src/components/common/Paging/Paging.module.scss
+++ b/client/src/components/common/Paging/Paging.module.scss
@@ -16,8 +16,7 @@
       color: $color-grey-400;
     }
   }
-  a,
-  span {
+  a {
     display: inline-block;
     width: 3rem;
     height: 3rem;
@@ -38,12 +37,3 @@
 /* ul.pagination li:last-child {
   border: none;
 } */
-
-.pages {
-  display: flex;
-  gap: 0.5rem;
-
-  & span {
-    cursor: pointer;
-  }
-}

--- a/client/src/components/common/Paging/Paging.module.scss
+++ b/client/src/components/common/Paging/Paging.module.scss
@@ -16,7 +16,8 @@
       color: $color-grey-400;
     }
   }
-  a {
+  a,
+  span {
     display: inline-block;
     width: 3rem;
     height: 3rem;
@@ -37,3 +38,12 @@
 /* ul.pagination li:last-child {
   border: none;
 } */
+
+.pages {
+  display: flex;
+  gap: 0.5rem;
+
+  & span {
+    cursor: pointer;
+  }
+}

--- a/client/src/components/home/MeetupItem/MeetupItem.module.scss
+++ b/client/src/components/home/MeetupItem/MeetupItem.module.scss
@@ -79,6 +79,18 @@
 }
 
 .field {
+  //   &.path-difficulty {
+  //     & .high {
+  //       color: #f61deb;
+  //     }
+  //     & .middle {
+  //       color: #eb8900;
+  //     }
+  //     & .low {
+  //       color: #00a1eb;
+  //     }
+  // }
+
   &.gathering-place {
     & .label {
       display: flex;

--- a/client/src/components/home/MeetupItem/MeetupItem.module.scss
+++ b/client/src/components/home/MeetupItem/MeetupItem.module.scss
@@ -15,6 +15,7 @@
   padding: 1.4rem 0 1.4rem 1.5rem;
   display: flex;
   flex-direction: column;
+  gap: 1.5rem;
   justify-content: space-between;
 }
 
@@ -28,7 +29,7 @@
   font-weight: 700;
   gap: 0.5rem;
   font-size: 1.4rem;
-  margin-top: 0.3rem;
+  margin-top: 0.4rem;
 
   & .location {
     color: $color-main;
@@ -42,34 +43,60 @@
 
 .info-wrapper {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   color: $color-grey-600;
   font-weight: 700;
   gap: 0.5rem;
   font-size: 1.2rem;
-  margin-top: 1.2rem;
-
-  & .courseName {
-    background: #cef2e2;
-    color: $color-main;
-    padding: 0.3rem 0.6rem;
-    border-radius: 0.3rem;
-  }
-
-  & .info,
-  .field {
-    display: flex;
-    gap: 0.4rem;
-  }
 
   & .emphasize {
     color: $color-main;
   }
 }
 
+.info-top,
+.info-bottom,
+.field {
+  display: flex;
+  align-items: center;
+}
+
+.info-top {
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  & .course-name {
+    background: #cef2e2;
+    color: $color-main;
+    padding: 0.3rem 0.6rem;
+    border-radius: 0.3rem;
+  }
+}
+
+.info-bottom,
+.field {
+  gap: 0.4rem;
+}
+
+.field {
+  &.gathering-place {
+    & .label {
+      display: flex;
+      gap: 0.1rem;
+      align-items: center;
+
+      & svg {
+        color: $color-main;
+        font-size: 1.3rem;
+      }
+    }
+  }
+}
+
 .img {
   width: 30%;
   object-fit: cover;
+  aspect-ratio: 1/1;
 }
 
 .path {

--- a/client/src/components/home/MeetupItem/index.tsx
+++ b/client/src/components/home/MeetupItem/index.tsx
@@ -3,6 +3,7 @@ import { MeetupData } from 'types/meetup';
 import classNames from 'classnames/bind';
 import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
+import { HiOutlineLocationMarker } from 'react-icons/hi';
 import { stringifyMeetupPathDifficulty } from 'utils/stringify';
 
 const cn = classNames.bind(styles);
@@ -11,64 +12,70 @@ interface MeetupItemProp {
   meetup: MeetupData;
 }
 
-const MeetupItem = ({
-  meetup: {
-    id,
-    meetingDate,
-    localLocation,
-    title,
-    courseName,
-    pathDifficulty,
-    joinPeople,
-    maxPeople,
-    meetingImgUrl,
-    path,
-  },
-}: MeetupItemProp) => {
+const MeetupItem = ({ meetup }: MeetupItemProp) => {
+  const path = meetup.path;
   const pathLength = path.length;
   const to = path[pathLength - 1];
   const restPathString = path.slice(0, pathLength - 1).join(' → ');
   return (
-    <Link to={`/meetups/${id}`}>
+    <Link to={`/meetups/${meetup.id}`}>
       <li className={cn('container')}>
         <div className={cn('preview')}>
           <div className={cn('text')}>
             <header className={cn('header')}>
               <span className={cn('meeting-date')}>
-                {dayjs(meetingDate).format('M월 D일')}
+                {dayjs(meetup.meetingDate).format('M월 D일')}
               </span>
-
               <div className={cn('title-wrapper')}>
-                <span className={cn('location')}>{localLocation}</span>
-                <h2 className={cn('title')}>{title}</h2>
+                <span className={cn('location')}>{meetup.localLocation}</span>
+                <h2 className={cn('title')}>{meetup.title}</h2>
               </div>
             </header>
 
             <div className={cn('info-wrapper')}>
-              {courseName && (
-                <span className={cn('courseName')}>{courseName}</span>
-              )}
-
-              <div className={cn('info')}>
+              <div className={cn('info-top')}>
+                {meetup.courseName && (
+                  <span className={cn('course-name')}>{meetup.courseName}</span>
+                )}
                 <div className={cn('field')}>
-                  <label className={cn('label')}>난이도</label>
+                  <label className={cn('label')}>
+                    <span>난이도</span>
+                  </label>
                   <span className={cn('emphasize')}>
-                    {stringifyMeetupPathDifficulty(pathDifficulty)}
+                    {stringifyMeetupPathDifficulty(meetup.pathDifficulty)}
                   </span>
                 </div>
+              </div>
+
+              <div className={cn('info-bottom')}>
+                <div className={cn('field', 'gathering-place')}>
+                  <label className={cn('label')}>
+                    <HiOutlineLocationMarker />
+                    <span>집결지</span>
+                  </label>
+                  <span className={cn('emphasize')}>
+                    {meetup.gatheringPlace}
+                  </span>
+                </div>
+
                 <span className={cn('dot')}>·</span>
+
                 <div className={cn('field')}>
                   <label className={cn('label')}>인원</label>
                   <div className={cn('nums')}>
-                    <span className={cn('emphasize')}>{joinPeople}</span>/
-                    {maxPeople}명
+                    <span className={cn('emphasize')}>{meetup.joinPeople}</span>
+                    /{meetup.maxPeople}명
                   </div>
                 </div>
               </div>
             </div>
           </div>
 
-          <img className={cn('img')} src={meetingImgUrl} alt={title} />
+          <img
+            className={cn('img')}
+            src={meetup.meetingImgUrl}
+            alt={meetup.title}
+          />
         </div>
 
         <div className={cn('path')}>

--- a/client/src/components/home/MeetupItem/index.tsx
+++ b/client/src/components/home/MeetupItem/index.tsx
@@ -37,11 +37,17 @@ const MeetupItem = ({ meetup }: MeetupItemProp) => {
                 {meetup.courseName && (
                   <span className={cn('course-name')}>{meetup.courseName}</span>
                 )}
-                <div className={cn('field')}>
+                <div className={cn('field', 'path-difficulty')}>
                   <label className={cn('label')}>
                     <span>난이도</span>
                   </label>
-                  <span className={cn('emphasize')}>
+                  <span
+                    className={cn('emphasize', {
+                      // high: meetup.pathDifficulty === 3,
+                      // middle: meetup.pathDifficulty === 2,
+                      // low: meetup.pathDifficulty === 1,
+                    })}
+                  >
                     {stringifyMeetupPathDifficulty(meetup.pathDifficulty)}
                   </span>
                 </div>

--- a/client/src/components/home/MeetupList/index.tsx
+++ b/client/src/components/home/MeetupList/index.tsx
@@ -9,7 +9,7 @@ interface MeetupListProp {
 const MeetupList = ({ meetups }: MeetupListProp) => (
   <ul className={styles.meetups}>
     {meetups.map(meetup => (
-      <MeetupItem meetup={meetup} />
+      <MeetupItem key={meetup.id} meetup={meetup} />
     ))}
   </ul>
 );

--- a/client/src/components/login/LoginForm/index.tsx
+++ b/client/src/components/login/LoginForm/index.tsx
@@ -59,8 +59,7 @@ const LoginForm = () => {
   }) => {
     try {
       await authAPI.login(email, password, isAuto, setUserId);
-      // TODO
-      // navigate(nextURL || '/');
+      navigate(nextURL || '/');
     } catch (e: any) {
       showToastMessage(getLoginFailErrorMessage(e.message));
     }

--- a/client/src/components/meetup/MeetupJoinBar/index.tsx
+++ b/client/src/components/meetup/MeetupJoinBar/index.tsx
@@ -46,6 +46,7 @@ const MeetupJoinBar = ({
     onSuccess: () => {
       showToastMessage('모임에 참가되었습니다. 즐거운 모임 되세요!');
       queryClient.invalidateQueries(['meetup', Number(meetupId)]);
+      queryClient.invalidateQueries(['meetups']);
     },
     onError: () => showToastMessage('모임 참가 중 문제가 발생했습니다.'),
   });

--- a/client/src/components/meetup/MeetupRoute/MeetupRoute.module.scss
+++ b/client/src/components/meetup/MeetupRoute/MeetupRoute.module.scss
@@ -31,7 +31,7 @@
   & svg {
     font-size: 1.7rem;
     position: absolute;
-    top: -1.1em;
+    top: -1.2em;
     right: -0.5em;
     color: $color-grey-600;
   }

--- a/client/src/components/meetups/MeetupCreationForm/index.tsx
+++ b/client/src/components/meetups/MeetupCreationForm/index.tsx
@@ -111,17 +111,17 @@ const MeetupCreationForm = ({ createMeetup }: MeetupCreationFormProp) => {
   });
 
   const showToastMessage = useSetRecoilState(toastMessageState);
-  const { data: courseNames, refetch } = useQuery<CourseName[]>(
-    ['courseNames'],
-    meetupAPI.getCourseNames,
-    {
-      enabled: false,
-      staleTime: 24 * 60 * 60 * 1000,
-      cacheTime: Infinity,
-      onError: () =>
-        showToastMessage('자전거길 목록 로딩 중 문제가 발생했습니다.'),
-    }
-  );
+  const {
+    data: courseNames,
+    refetch,
+    isLoading,
+  } = useQuery<CourseName[]>(['courseNames'], meetupAPI.getCourseNames, {
+    enabled: false,
+    staleTime: 24 * 60 * 60 * 1000,
+    cacheTime: Infinity,
+    onError: () =>
+      showToastMessage('자전거길 목록 로딩 중 문제가 발생했습니다.'),
+  });
 
   const imgFile = watch('meetingImgUrl');
   const dueDate = watch('dueDate');
@@ -402,7 +402,7 @@ const MeetupCreationForm = ({ createMeetup }: MeetupCreationFormProp) => {
             name="courseName"
             render={({ field: { onChange, ...others } }) => (
               <Autocomplete
-                loading={!courseNames}
+                loading={isLoading}
                 loadingText="목록을 불러오고 있습니다"
                 noOptionsText="데이터가 존재하지 않습니다."
                 options={courseNames || []}

--- a/client/src/components/meetups/MeetupFilterBoard/index.tsx
+++ b/client/src/components/meetups/MeetupFilterBoard/index.tsx
@@ -20,7 +20,6 @@ const MeetupFilterBoard = ({ close }: MeetupFilterBoardProp) => {
     meetupBoardFiltersState,
     MEETUP_FILTERS_REDUCERS
   );
-  console.log(boardFilters);
 
   const showToastMessage = useSetRecoilState(toastMessageState);
   const setFilters = useSetRecoilState(meetupFiltersState);

--- a/client/src/components/meetups/MeetupFilterBoardOptions/index.tsx
+++ b/client/src/components/meetups/MeetupFilterBoardOptions/index.tsx
@@ -357,7 +357,7 @@ const MeetupFilterBoardOptions = () => {
           <CheckBox
             id={cn('participation-fee')}
             shape="square"
-            isChecked={Boolean(boardFilters.participationFee)}
+            isChecked={!!boardFilters.participationFee}
             onChange={toggleSpecificOption(IS_PARTICIPATION_FREE_PAYLOAD)}
           />
           <label htmlFor={cn('participation-fee')}>

--- a/client/src/components/meetups/MeetupFilterChoices/index.tsx
+++ b/client/src/components/meetups/MeetupFilterChoices/index.tsx
@@ -98,7 +98,7 @@ const MeetupFilterChoices = ({ onBoard }: MeetupFilterChoicesProp) => {
           onXClick={handleRemove}
         />
       )}
-      {Boolean(
+      {!!(
         filters.minNumOfParticipants.value || filters.maxNumOfParticipants.value
       ) && (
         <FilterOptionChip

--- a/client/src/components/meetups/Pagination/Pagination.module.scss
+++ b/client/src/components/meetups/Pagination/Pagination.module.scss
@@ -1,0 +1,37 @@
+@use '../../../styles/variables.scss' as *;
+
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1.2rem;
+  color: $color-grey-600;
+  font-size: 1.4rem;
+  margin-top: 5rem;
+
+  & button:disabled {
+    color: $color-grey-400;
+  }
+}
+
+.pages {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.page {
+  cursor: pointer;
+  width: 3rem;
+  height: 3rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+
+  &:hover,
+  &.active {
+    background: $color-main;
+    color: white;
+    transition: all 0.2s ease-in-out;
+  }
+}

--- a/client/src/components/meetups/Pagination/index.tsx
+++ b/client/src/components/meetups/Pagination/index.tsx
@@ -1,0 +1,76 @@
+import styles from '../../common/Paging/Paging.module.scss';
+import classNames from 'classnames/bind';
+import { SetterOrUpdater } from 'recoil';
+
+const cn = classNames.bind(styles);
+
+const PAGE_LIMIT = 5;
+function getPageGroupIndex(page: number) {
+  return Math.floor((page - 1) / PAGE_LIMIT);
+}
+
+interface PaginationProps {
+  currentPage: number;
+  setCurrentPage: SetterOrUpdater<number>;
+  lastPage: number;
+}
+
+const Pagination = ({
+  currentPage,
+  setCurrentPage,
+  lastPage,
+}: PaginationProps) => {
+  const totalPages = Array.from({ length: lastPage }, (_, index) => index + 1);
+
+  const pageGroups: { [index: string]: number[] } = {};
+  for (
+    let pageGroupIndex = 0;
+    pageGroupIndex <= getPageGroupIndex(lastPage);
+    pageGroupIndex++
+  ) {
+    pageGroups[pageGroupIndex] = totalPages.slice(
+      PAGE_LIMIT * pageGroupIndex,
+      PAGE_LIMIT * pageGroupIndex + PAGE_LIMIT
+    );
+  }
+
+  const getPageClickHandler = (page: number) => () => setCurrentPage(page);
+  const handlePreviousClick = () =>
+    setCurrentPage(page => PAGE_LIMIT * (getPageGroupIndex(page) - 1) + 1);
+  const handleNextClick = () =>
+    setCurrentPage(page => PAGE_LIMIT * (getPageGroupIndex(page) + 1) + 1);
+
+  return (
+    <nav className={cn('container')}>
+      <button
+        onClick={handlePreviousClick}
+        disabled={!getPageGroupIndex(currentPage)}
+      >
+        &lt;
+      </button>
+
+      <div className={cn('pages')}>
+        {pageGroups[getPageGroupIndex(currentPage)].map(page => (
+          <span
+            key={page}
+            className={cn('page', { active: page === currentPage })}
+            onClick={getPageClickHandler(page)}
+          >
+            {page}
+          </span>
+        ))}
+      </div>
+
+      <button
+        onClick={handleNextClick}
+        disabled={
+          getPageGroupIndex(currentPage) === getPageGroupIndex(lastPage)
+        }
+      >
+        &gt;
+      </button>
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/client/src/components/meetups/Pagination/index.tsx
+++ b/client/src/components/meetups/Pagination/index.tsx
@@ -1,4 +1,4 @@
-import styles from '../../common/Paging/Paging.module.scss';
+import styles from './Pagination.module.scss';
 import classNames from 'classnames/bind';
 import { SetterOrUpdater } from 'recoil';
 

--- a/client/src/components/signup/SignupBasicForm/index.tsx
+++ b/client/src/components/signup/SignupBasicForm/index.tsx
@@ -78,7 +78,7 @@ const SignupBasicForm = () => {
               <AuthFormInput
                 type="email"
                 placeholder="이메일"
-                hasError={Boolean(errors.email)}
+                hasError={!!errors.email}
                 {...field}
               />
             )}
@@ -110,7 +110,7 @@ const SignupBasicForm = () => {
                 type="password"
                 placeholder="비밀번호"
                 helpText={!isSubmitted && '비밀번호 조건'}
-                hasError={Boolean(errors.password)}
+                hasError={!!errors.password}
                 {...field}
               />
             )}
@@ -140,7 +140,7 @@ const SignupBasicForm = () => {
               <AuthFormInput
                 type="password"
                 placeholder="비밀번호 확인"
-                hasError={Boolean(errors.passwordConfirm)}
+                hasError={!!errors.passwordConfirm}
                 {...field}
               />
             )}

--- a/client/src/components/signup/SignupDetailForm/index.tsx
+++ b/client/src/components/signup/SignupDetailForm/index.tsx
@@ -116,7 +116,7 @@ const SignupDetailForm = () => {
               <AuthFormInput
                 placeholder="닉네임"
                 helpText={!isSubmitted && '닉네임 조건'}
-                hasError={Boolean(errors.nickname)}
+                hasError={!!errors.nickname}
                 {...field}
               />
             )}
@@ -176,7 +176,7 @@ const SignupDetailForm = () => {
                 type="number"
                 placeholder="출생년도"
                 helpText={!isSubmitted && '출생년도 네자리'}
-                hasError={Boolean(errors.birthYear)}
+                hasError={!!errors.birthYear}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
                   const input = e.target.value;
                   if (Number(input) < 0) {
@@ -270,7 +270,7 @@ const SignupDetailForm = () => {
               <AuthFormInput
                 placeholder="상태 메세지"
                 helpText={!isSubmitted && '상태 메세지 조건'}
-                hasError={Boolean(errors.introduce)}
+                hasError={!!errors.introduce}
                 {...field}
               />
             )}

--- a/client/src/routes/Home/index.tsx
+++ b/client/src/routes/Home/index.tsx
@@ -22,6 +22,7 @@ const Home = () => {
     () => meetupAPI.getMeetupList(),
     {
       select: meetups =>
+        // TODO: 삭제
         getMeetupsOrderedBy(
           '-createdAt',
           meetups.filter(meetup => dayjs().isBefore(dayjs(meetup.dueDate)))

--- a/client/src/routes/Home/index.tsx
+++ b/client/src/routes/Home/index.tsx
@@ -9,19 +9,23 @@ import { meetupAPI } from 'apis/meetupAPI';
 import { toastMessageState } from 'states/common';
 import dayjs from 'dayjs';
 import MeetupList from 'components/home/MeetupList';
+import { getMeetupsOrderedBy } from 'utils/order';
 
 const cn = classNames.bind(styles);
+
+const MAX_NUM_OF_ITEMS = 3;
 
 const Home = () => {
   const showToastMessage = useSetRecoilState(toastMessageState);
   const { data: meetups } = useQuery<MeetupData[]>(
     ['meetups'],
-    meetupAPI.getMeetupList,
+    () => meetupAPI.getMeetupList(),
     {
       select: meetups =>
-        meetups
-          .filter(meetup => dayjs().isBefore(dayjs(meetup.dueDate)))
-          .slice(0, 3),
+        getMeetupsOrderedBy(
+          '-createdAt',
+          meetups.filter(meetup => dayjs().isBefore(dayjs(meetup.dueDate)))
+        ).slice(0, MAX_NUM_OF_ITEMS),
       staleTime: 10 * 60 * 1000,
       cacheTime: Infinity,
       onError: () => showToastMessage('로딩 중 문제가 발생했습니다.'),

--- a/client/src/routes/Home/index.tsx
+++ b/client/src/routes/Home/index.tsx
@@ -13,7 +13,7 @@ import { getMeetupsOrderedBy } from 'utils/order';
 
 const cn = classNames.bind(styles);
 
-const MAX_NUM_OF_ITEMS = 3;
+const MAX_NUM_OF_ITEMS = 5;
 
 const Home = () => {
   const showToastMessage = useSetRecoilState(toastMessageState);
@@ -22,7 +22,7 @@ const Home = () => {
     () => meetupAPI.getMeetupList(),
     {
       select: meetups =>
-        // TODO: 삭제
+        // TODO: 정렬 삭제
         getMeetupsOrderedBy(
           '-createdAt',
           meetups.filter(meetup => dayjs().isBefore(dayjs(meetup.dueDate)))

--- a/client/src/routes/Meetup/Meetup.module.scss
+++ b/client/src/routes/Meetup/Meetup.module.scss
@@ -2,7 +2,7 @@
 @use '../../styles/variables.scss' as *;
 
 .container {
-  padding-bottom: 2rem;
+  padding-bottom: 6rem;
 }
 
 .img-wrapper {

--- a/client/src/routes/Meetup/index.tsx
+++ b/client/src/routes/Meetup/index.tsx
@@ -271,12 +271,12 @@ const Meetup = () => {
         )}
       </section>
 
-      <section className={cn('comments-section')}>
+      {/* <section className={cn('comments-section')}>
         <h2 className={cn('subtitle')}>
           댓글
           <span className={cn('subtitle__num')}>12</span>
         </h2>
-      </section>
+      </section> */}
 
       <MeetupJoinBar {...getJoinBarProps(meetup as MeetupDetail, userId)} />
     </div>

--- a/client/src/routes/Meetup/index.tsx
+++ b/client/src/routes/Meetup/index.tsx
@@ -22,7 +22,16 @@ import Loading from 'components/common/Loading';
 import { userIdState } from 'states/auth';
 import MeetupJoinBar from 'components/meetup/MeetupJoinBar';
 import MeetupParticipantList from 'components/meetup/MeetupParticipantList';
-import { MeetupDetail } from 'types/meetup';
+import {
+  MeetupCourseName,
+  MeetupDetail,
+  MeetupGatheringPlace,
+  MeetupGender,
+  MeetupParticipant,
+  MeetupPath,
+  MeetupPathDifficulty,
+  MeetupRidingSkill,
+} from 'types/meetup';
 
 // const testPath = [
 //   '안합',
@@ -85,7 +94,7 @@ const Meetup = () => {
   const { meetupId } = useParams();
   const userId = useRecoilValue(userIdState);
   const showToastMessage = useSetRecoilState(toastMessageState);
-  const { data: meetup } = useQuery<MeetupDetail>(
+  const { data: meetup, isLoading } = useQuery<MeetupDetail>(
     ['meetup', Number(meetupId)],
     () => meetupAPI.getMeetupDetail(Number(meetupId)),
     {
@@ -99,23 +108,23 @@ const Meetup = () => {
     window.scrollY && window.scrollTo({ top: 0 });
   }, []); // TODO: 리스트 스크롤 위치 기억
 
-  if (!meetup) return <Loading />;
-  const imgStyle = {
-    backgroundImage: `linear-gradient(to bottom, rgba(0,0,0,0) 60%, rgba(255,255,255,0.9)), url(${meetup.meetingImgUrl})`,
-  };
+  if (isLoading) return <Loading />;
 
+  const imgStyle = {
+    backgroundImage: `linear-gradient(to bottom, rgba(0,0,0,0) 60%, rgba(255,255,255,0.9)), url(${meetup?.meetingImgUrl})`,
+  };
   console.log(meetup);
   return (
     <div className={cn('container')}>
       <div
         className={cn('img-wrapper', {
-          default: meetup.meetingImgUrl === MEETUP_DEFAULT_IMAGE,
+          default: meetup?.meetingImgUrl === MEETUP_DEFAULT_IMAGE,
         })}
         style={imgStyle}
       />
 
       <div className={cn('title-wrapper')}>
-        <h1 className={cn('title')}>{meetup.title}</h1>
+        <h1 className={cn('title')}>{meetup?.title}</h1>
         <button className={cn('bookmark-btn')} aria-label="모임 북마크 버튼">
           {/* TODO: active */}
           <BsBookmark />
@@ -126,11 +135,11 @@ const Meetup = () => {
       <div className={cn('leader')}>
         <img
           className={cn('leader__avatar')}
-          src={meetup.admin.profile_img_url}
-          alt={meetup.admin.nickname}
+          src={meetup?.admin.profile_img_url}
+          alt={meetup?.admin.nickname}
         />
-        <span className={cn('leader__nickname')}>{meetup.admin.nickname}</span>
-        <span className={cn('leader__manner')}>{meetup.admin.manner}°C</span>
+        <span className={cn('leader__nickname')}>{meetup?.admin.nickname}</span>
+        <span className={cn('leader__manner')}>{meetup?.admin.manner}°C</span>
       </div>
 
       <section className={cn('fields-section')}>
@@ -138,21 +147,21 @@ const Meetup = () => {
           <div className={cn('field')}>
             <label className={cn('label')}>지역</label>
             <span className={cn('data', 'emphasized')}>
-              {meetup.localLocation}
+              {meetup?.localLocation}
             </span>
           </div>
 
           <div className={cn('field')}>
             <label className={cn('label')}>집결지</label>
             <span className={cn('data', 'emphasized')}>
-              {meetup.gatheringPlace}
+              {meetup?.gatheringPlace}
             </span>
           </div>
 
           <div className={cn('field')}>
             <label className={cn('label')}>모임 일시</label>
             <span className={cn('data', 'emphasized')}>
-              {dayjs(meetup.meetingDate).format(DATE_FORMAT)}
+              {dayjs(meetup?.meetingDate).format(DATE_FORMAT)}
             </span>
           </div>
         </div>
@@ -161,14 +170,16 @@ const Meetup = () => {
           <div className={cn('field')}>
             <label className={cn('label')}>코스 난이도</label>
             <span className={cn('data', 'emphasized')}>
-              {stringifyMeetupPathDifficulty(meetup.pathDifficulty)}
+              {stringifyMeetupPathDifficulty(
+                meetup?.pathDifficulty as MeetupPathDifficulty
+              )}
             </span>
           </div>
 
           <div className={cn('field')}>
             <label className={cn('label')}>자전거 종류</label>
             <ul className={cn('data')}>
-              {meetup.bicycleTypes.map((type: BicycleType) => (
+              {meetup?.bicycleTypes.map((type: BicycleType) => (
                 <li key={type} className={cn('emphasized')}>
                   {type}
                 </li>
@@ -181,24 +192,24 @@ const Meetup = () => {
           <div className={cn('field')}>
             <label className={cn('label')}>인원</label>
             <div className={cn('data')}>
-              <span className={cn('emphasized')}>{meetup.joinPeople}</span>/
-              {meetup.maxPeople}명
+              <span className={cn('emphasized')}>{meetup?.joinPeople}</span>/
+              {meetup?.maxPeople}명
             </div>
           </div>
 
           <div className={cn('field')}>
             <label className={cn('label')}>성별</label>
             <span className={cn('data', 'emphasized')}>
-              {stringifyGender(meetup.gender)}
+              {stringifyGender(meetup?.gender as MeetupGender)}
             </span>
           </div>
 
           <div className={cn('field')}>
             <label className={cn('label')}>나이</label>
             <div className={cn('data')}>
-              <span className={cn('emphasized')}>{meetup.minBirthYear}</span>
+              <span className={cn('emphasized')}>{meetup?.minBirthYear}</span>
               년생 ~{' '}
-              <span className={cn('emphasized')}>{meetup.maxBirthYear}</span>
+              <span className={cn('emphasized')}>{meetup?.maxBirthYear}</span>
               년생
             </div>
           </div>
@@ -206,7 +217,7 @@ const Meetup = () => {
           <div className={cn('field')}>
             <label className={cn('label')}>라이딩 실력</label>
             <span className={cn('data', 'emphasized')}>
-              {stringifyRidingSkill(meetup.ridingSkill)}
+              {stringifyRidingSkill(meetup?.ridingSkill as MeetupRidingSkill)}
             </span>
           </div>
 
@@ -214,7 +225,7 @@ const Meetup = () => {
             <label className={cn('label')}>참가비</label>
             <div className={cn('data')}>
               <span className={cn('emphasized')}>
-                {meetup.participationFee.toLocaleString()}
+                {meetup?.participationFee.toLocaleString()}
               </span>
               원
             </div>
@@ -223,18 +234,21 @@ const Meetup = () => {
       </section>
 
       <section className={cn('content-section')}>
-        <p className={cn('content')}>{meetup.content}</p>
+        <p className={cn('content')}>{meetup?.content}</p>
       </section>
 
       <section className={cn('route-section')}>
-        <MeetupRoute courseName={meetup.courseName} path={meetup.path} />
+        <MeetupRoute
+          courseName={meetup?.courseName as MeetupCourseName}
+          path={meetup?.path as MeetupPath}
+        />
       </section>
 
       {/* TODO: 아이콘 설명 */}
       <section className={cn('map-section')}>
         <MeetupPathMap
-          gatheringPlace={meetup.gatheringPlace}
-          path={meetup.path}
+          gatheringPlace={meetup?.gatheringPlace as MeetupGatheringPlace}
+          path={meetup?.path as MeetupPath}
         />
         <div className={cn('notice')}>
           <p>* 위 지도는 장소의 위치를 대략적으로 나타내고 있습니다.</p>
@@ -246,12 +260,14 @@ const Meetup = () => {
         <h2 className={cn('subtitle')}>
           참가 멤버
           <div className={cn('subtitle__num')}>
-            <span className={cn('current')}>{meetup.joinPeople}</span>/
-            {meetup.maxPeople}
+            <span className={cn('current')}>{meetup?.joinPeople}</span>/
+            {meetup?.maxPeople}
           </div>
         </h2>
-        {Boolean(meetup.joinPeople) && (
-          <MeetupParticipantList participants={meetup.participants} />
+        {!!meetup?.joinPeople && (
+          <MeetupParticipantList
+            participants={meetup?.participants as MeetupParticipant[]}
+          />
         )}
       </section>
 
@@ -262,7 +278,7 @@ const Meetup = () => {
         </h2>
       </section>
 
-      <MeetupJoinBar {...getJoinBarProps(meetup, userId)} />
+      <MeetupJoinBar {...getJoinBarProps(meetup as MeetupDetail, userId)} />
     </div>
   );
 };

--- a/client/src/routes/Meetups/index.tsx
+++ b/client/src/routes/Meetups/index.tsx
@@ -18,12 +18,11 @@ import { useQuery } from '@tanstack/react-query';
 import Loading from 'components/common/Loading';
 import { toastMessageState } from 'states/common';
 import { MeetupData } from 'types/meetup';
-import Paging from 'components/common/Paging';
-import { useSearchParams } from 'react-router-dom';
+import Pagination from 'components/meetups/Pagination';
 
 const cn = classNames.bind(styles);
 
-const PAGE_LIMIT = 6;
+const ITEMS_LIMIT = 6;
 
 // TODO: 렌더링 확인
 const Meetups = () => {
@@ -32,7 +31,7 @@ const Meetups = () => {
   // const [page, setPage] = useState(
   //   Number(useSearchParams()[0].get('page')) || 1
   // );
-  const offset = PAGE_LIMIT * (page - 1);
+  const itemsOffset = ITEMS_LIMIT * (page - 1);
   // TODO: useState로
   const order = useRecoilValue(meetupOrderState);
 
@@ -42,6 +41,7 @@ const Meetups = () => {
     ['meetups', filters],
     () => meetupAPI.getMeetupList(filters),
     {
+      // TODO: order 디폴트 null?
       select: meetups => getMeetupsOrderedBy(order.name, meetups),
       staleTime: 5 * 60 * 1000,
       cacheTime: Infinity,
@@ -51,6 +51,7 @@ const Meetups = () => {
 
   const resetOrder = useResetRecoilState(meetupOrderState);
   const resetFilters = useResetRecoilState(meetupFiltersState);
+  useEffect(() => setPage(1), [filters, order.name]);
   useEffect(() => resetOrder, []);
   useEffect(() => resetFilters, []);
 
@@ -80,22 +81,22 @@ const Meetups = () => {
 
       <div className={cn('meetups-wrapper')}>
         {meetups ? (
-          // TODO: order 디폴트 null?
-          <MeetupList meetups={meetups} />
+          <MeetupList
+            meetups={meetups.slice(itemsOffset, itemsOffset + ITEMS_LIMIT)}
+          />
         ) : (
-          // <MeetupList meetups={meetups.slice(offset, offset + PAGE_LIMIT)} />
+          // <MeetupList meetups={meetups} />
           <Loading />
         )}
       </div>
 
-      {/* {meetups && (
-        <Paging
-          total={meetups.length}
-          limit={PAGE_LIMIT}
-          page={page}
-          setPage={setPage}
+      {meetups && (
+        <Pagination
+          currentPage={page}
+          setCurrentPage={setPage}
+          lastPage={Math.ceil(meetups.length / ITEMS_LIMIT)}
         />
-      )} */}
+      )}
     </div>
   );
 };

--- a/client/src/routes/Meetups/index.tsx
+++ b/client/src/routes/Meetups/index.tsx
@@ -37,7 +37,7 @@ const Meetups = () => {
 
   const filters = useRecoilValue(meetupFiltersState);
   const showToastMessage = useSetRecoilState(toastMessageState);
-  const { data: meetups } = useQuery<MeetupData[]>(
+  const { data: meetups, isLoading } = useQuery<MeetupData[]>(
     ['meetups', filters],
     () => meetupAPI.getMeetupList(filters),
     {
@@ -80,17 +80,19 @@ const Meetups = () => {
       <MeetupFilterChoices />
 
       <div className={cn('meetups-wrapper')}>
-        {meetups ? (
+        {isLoading ? (
+          <Loading />
+        ) : meetups?.length ? (
           <MeetupList
             meetups={meetups.slice(itemsOffset, itemsOffset + ITEMS_LIMIT)}
           />
         ) : (
-          // <MeetupList meetups={meetups} />
-          <Loading />
+          <p>결과 없음</p>
         )}
       </div>
 
-      {meetups && (
+      {/* TODO: refactor */}
+      {!!meetups?.length && (
         <Pagination
           currentPage={page}
           setCurrentPage={setPage}

--- a/client/src/routes/Meetups/index.tsx
+++ b/client/src/routes/Meetups/index.tsx
@@ -19,6 +19,7 @@ import Loading from 'components/common/Loading';
 import { toastMessageState } from 'states/common';
 import { MeetupData } from 'types/meetup';
 import Pagination from 'components/meetups/Pagination';
+import NoResults from 'components/common/NoResults';
 
 const cn = classNames.bind(styles);
 
@@ -87,7 +88,7 @@ const Meetups = () => {
             meetups={meetups.slice(itemsOffset, itemsOffset + ITEMS_LIMIT)}
           />
         ) : (
-          <p>결과 없음</p>
+          <NoResults />
         )}
       </div>
 

--- a/client/src/routes/Meetups/index.tsx
+++ b/client/src/routes/Meetups/index.tsx
@@ -28,29 +28,31 @@ const PAGE_LIMIT = 6;
 // TODO: 렌더링 확인
 const Meetups = () => {
   const userId = useRecoilValue(userIdState);
+  const [page, setPage] = useState(1);
+  // const [page, setPage] = useState(
+  //   Number(useSearchParams()[0].get('page')) || 1
+  // );
+  const offset = PAGE_LIMIT * (page - 1);
   // TODO: useState로
   const order = useRecoilValue(meetupOrderState);
-  const filters = useRecoilValue(meetupFiltersState);
-  const [page, setPage] = useState(
-    Number(useSearchParams()[0].get('page')) || 1
-  );
-  const offset = PAGE_LIMIT * (page - 1);
 
+  const filters = useRecoilValue(meetupFiltersState);
   const showToastMessage = useSetRecoilState(toastMessageState);
   const { data: meetups } = useQuery<MeetupData[]>(
-    ['meetups'],
-    meetupAPI.getMeetupList,
+    ['meetups', filters],
+    () => meetupAPI.getMeetupList(filters),
     {
+      select: meetups => getMeetupsOrderedBy(order.name, meetups),
       staleTime: 5 * 60 * 1000,
       cacheTime: Infinity,
       onError: () => showToastMessage('로딩 중 문제가 발생했습니다.'),
     }
   );
 
-  const resetFilters = useResetRecoilState(meetupFiltersState);
   const resetOrder = useResetRecoilState(meetupOrderState);
-  useEffect(() => resetFilters, []);
+  const resetFilters = useResetRecoilState(meetupFiltersState);
   useEffect(() => resetOrder, []);
+  useEffect(() => resetFilters, []);
 
   return (
     <div>
@@ -79,25 +81,21 @@ const Meetups = () => {
       <div className={cn('meetups-wrapper')}>
         {meetups ? (
           // TODO: order 디폴트 null?
-          <MeetupList
-            meetups={getMeetupsOrderedBy(
-              order.name,
-              meetups as MeetupData[]
-            ).slice(offset, offset + PAGE_LIMIT)}
-          />
+          <MeetupList meetups={meetups} />
         ) : (
+          // <MeetupList meetups={meetups.slice(offset, offset + PAGE_LIMIT)} />
           <Loading />
         )}
       </div>
 
-      {meetups && (
+      {/* {meetups && (
         <Paging
-          total={(meetups as MeetupData[]).length}
+          total={meetups.length}
           limit={PAGE_LIMIT}
           page={page}
           setPage={setPage}
         />
-      )}
+      )} */}
     </div>
   );
 };


### PR DESCRIPTION
## 관련 이슈

closes #127 

## 작업 내용
- components > meetups > `Pagination`: 기존 `Paging` 이랑 모임 필터랑 기능이 꼬여서 모임은 `Pagination` 을 일단 따로 만들었습니다 😢 지금은 필터/정렬/페이징 URL 반영은 차후에 하려고 합니다..
- 모임 필터 API 연결: `filters` state가 변경될 때마다 react-query가 새로 실행됨
- components > common > `NoResults`: 필터/검색 결과가 없을 때 활용
- 메인 페이지 모임 UI 수정: 모바일로 보니 두 줄이 되는 경우가 생겨서 필드 순서를 바꿨고, 집결지 필드가 중요한 것 같아 추가함
- components > routes > `Meetups`/`Meetup` 에서 react-query `isLoading` 활용