### PR TITLE
refactor: 좋아요 생성 시 좋아요 id를 리턴하도록 코드 수정(#147)

### DIFF
--- a/src/main/java/com/joyride/ms/src/course/CourseDao.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseDao.java
@@ -122,12 +122,15 @@ public class CourseDao {
     /**
      * 코스 좋아요
      */
-    public void insertCourseLike(int user_id, String title){
+    public int insertCourseLike(int user_id, String title){
 
         String createCourseLikeQuery = "insert into courselike (user_id, course_id) VALUES (?,?)";
 
         Object[] createCourseLikeParams = new Object[]{user_id, title};
         this.jdbcTemplate.update(createCourseLikeQuery, createCourseLikeParams);
+
+        String lastInsertIdQuery = "select last_insert_id()";
+        return this.jdbcTemplate.queryForObject(lastInsertIdQuery,int.class);
     }
 
     //좋아요 삭제
@@ -147,7 +150,7 @@ public class CourseDao {
                 existsCourseLikeParams);
     }
 
-    public List<String> selectCourseByUserId(int user_id) {
+    public List<String>selectCourseByUserId(int user_id) {
         String selectCourseByUserIdQuery = "select course_id from courselike where user_id = ?";
         int selectCourseByUserIdParams = user_id;
         return this.jdbcTemplate.query(selectCourseByUserIdQuery,

--- a/src/main/java/com/joyride/ms/src/course/CourseService.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseService.java
@@ -120,13 +120,13 @@ public class CourseService {
             List<String> selectedTitle = courseDao.selectCourseByUserId(user_id);
             // 코스 좋아요가 있으면
             if (selectedTitle.contains(title)) {
-                courseDao.selectCourseByUserId(user_id);
                 String message = "좋아요가 이미 존재합니다.";
-                return new PostCourseLikeRes(message);
+                int id = -1;
+                return new PostCourseLikeRes(message, id);
             }
-            courseDao.insertCourseLike(user_id, title);
+            int likeId = courseDao.insertCourseLike(user_id, title);
             String message = "좋아요 등록 성공했습니다.";
-            return new PostCourseLikeRes(message);
+            return new PostCourseLikeRes(message, likeId);
         } catch (Exception exception) {
             exception.printStackTrace();
             throw new BaseException(DATABASE_ERROR);

--- a/src/main/java/com/joyride/ms/src/course/model/PostCourseLikeRes.java
+++ b/src/main/java/com/joyride/ms/src/course/model/PostCourseLikeRes.java
@@ -7,5 +7,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostCourseLikeRes {
+
     private String message;
+    private int likeId;
 }


### PR DESCRIPTION
## 관련 이슈

closes #147 

## 작업 내용
1. 좋아요 생성 시 좋아요 id를 return 하도록 코드 수정
좋아요가 생성 시 "좋아요 등록 성공했습니다." 라는 메세지와 id로 해당 좋아요 아이디 값을 리턴하도록 했습니다. 
좋아요가 이미 있을 때는 "좋아요가 이미 존재합니다." 라는 메세지와 id로 -1값을 리턴하도록 했습니다. 