### PR TITLE
refactor: 좋아요 조회&삭제 api 수정(#159)

### DIFF
--- a/src/main/java/com/joyride/ms/src/course/CourseController.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseController.java
@@ -150,11 +150,11 @@ public class CourseController {
     }
 
     //코스 종아요 취소 api
-    @DeleteMapping("/like/{courseLike_id}")
-    public BaseResponse<DeleteCourseLikeRes> PatchCourseReviewStatus(@PathVariable("courseLike_id") int courseLike_id){
+    @DeleteMapping("/like/{title}/{user_id}")
+    public BaseResponse<DeleteCourseLikeRes> DeleteCourseLike(@PathVariable("title") String title, @PathVariable("user_id") int user_id){
         try{
             // 유저 확인 로직 필요
-            DeleteCourseLikeRes deleteCourseReviewRes = courseService.removeCourseLike(courseLike_id);
+            DeleteCourseLikeRes deleteCourseReviewRes = courseService.removeCourseLike(title, user_id);
             return new BaseResponse<>(deleteCourseReviewRes);
         } catch(BaseException exception){
             return new BaseResponse<>((exception.getStatus()));

--- a/src/main/java/com/joyride/ms/src/course/CourseDao.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseDao.java
@@ -143,17 +143,17 @@ public class CourseDao {
     }
 
     //좋아요 삭제
-    public void deleteCourseLike(int courseLike_id){
+    public void deleteCourseLike(String title, int user_id){
         // 이 부분 체크
-        String deleteByCourseLikeIdQuery = "delete from courselike where id = ?";
-        int deleteByCourseLikeIdParams = courseLike_id;
+        String deleteByCourseLikeIdQuery = "delete from courselike where course_id = ? and user_id = ?";
+        Object[] deleteCourseLikeParams = new Object[]{title, user_id};
 
-        this.jdbcTemplate.update(deleteByCourseLikeIdQuery, deleteByCourseLikeIdParams);
+        this.jdbcTemplate.update(deleteByCourseLikeIdQuery, deleteCourseLikeParams);
     }
 
-    public int existsCourseLike(int courseLike_id) {
-        String existsCourseLikeQuery = "select exists(select id from courselike where id = ?)";
-        int existsCourseLikeParams = courseLike_id;
+    public int existsCourseLike(String title, int user_id) {
+        String existsCourseLikeQuery = "select exists(select id from courselike where course_id = ? and user_id = ?)";
+        Object[] existsCourseLikeParams = new Object[]{title, user_id};
         return this.jdbcTemplate.queryForObject(existsCourseLikeQuery,
                 int.class,
                 existsCourseLikeParams);

--- a/src/main/java/com/joyride/ms/src/course/CourseProvider.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseProvider.java
@@ -200,14 +200,13 @@ public class CourseProvider {
     public GetCourseLikeRes retrieveCourseLike(GetCourseLikeReq getCourseLikeReq) throws BaseException {
         try{
             String title = getCourseLikeReq.getTitle();
-            int id = getCourseLikeReq.getUser_id();
-            List<String> selectedTitle = courseDao.selectCourseByUserId(id);
-            System.out.println("selectedTitle = " + selectedTitle);
-            if (selectedTitle.contains(title)) {
-                return  new GetCourseLikeRes(1);
+            int user_id = getCourseLikeReq.getUser_id();
+            int courseId = courseDao.existsCourseLike(title, user_id);
+            if (courseId == 0) {
+                return new GetCourseLikeRes(0);
             }
 
-            return  new GetCourseLikeRes(0);
+            return new GetCourseLikeRes(1);
         }
         catch (Exception exception) {
             exception.printStackTrace();

--- a/src/main/java/com/joyride/ms/src/course/CourseService.java
+++ b/src/main/java/com/joyride/ms/src/course/CourseService.java
@@ -134,15 +134,15 @@ public class CourseService {
     }
 
     //코스 좋아요 삭제
-    public DeleteCourseLikeRes removeCourseLike(int courseLike_id) throws BaseException {
+    public DeleteCourseLikeRes removeCourseLike(String title , int user_id) throws BaseException {
 
         // 유저확인 로직 필요
-        int existsCourseLike = courseDao.existsCourseLike(courseLike_id);
+        int existsCourseLike = courseDao.existsCourseLike(title, user_id);
         if (existsCourseLike == 0) {
             throw new BaseException(COURSE_LIKE_NOT_EXISTS);
         }
         try{
-            courseDao.deleteCourseLike(courseLike_id);
+            courseDao.deleteCourseLike(title, user_id);
             String message = "좋아요 삭제에 성공했습니다.";
             return new DeleteCourseLikeRes(message);
         } catch (Exception exception) {


### PR DESCRIPTION
## 관련 이슈

closes #159 

## 작업 내용
좋아요 조회&삭제 api 수정
좋아요 삭제 시 코스 아이디가 아니라 유저 아이디와 타이틀을 받아서 삭제하도록 코드 수정
## Test scenario or New setup

_(ex: 라이브러리 추가되었습니다.)_
