### PR TITLE
hotfix: 코스 필터링 로직, 프로필 사진 파일 크기 제한, 정보 변경 완료 시 알림 

### DIFF
--- a/client/src/apis/coursesAPI.ts
+++ b/client/src/apis/coursesAPI.ts
@@ -1,4 +1,6 @@
-import { uniqBy } from 'lodash';
+import { COURSE_FILTERS_INITIAL_STATE } from 'states/course';
+import QueryString from 'qs';
+import { mapValues, uniqBy } from 'lodash';
 // const BASE_URL = 'http://localhost:3000';
 const BASE_URL = `https://apis.data.go.kr/B551011/Durunubi/courseList?MobileOS=ETC&MobileApp=joyride&ServiceKey=${process.env.REACT_APP_TOUR_API_KEY}&brdDiv=DNBW`;
 const SERVER_URL = process.env.REACT_APP_JOYRIDE_API_URL;
@@ -41,8 +43,12 @@ export function fetchCourseInfo(courseNm: string | undefined) {
   //   return fetch(`${BASE_URL}/course:${id}`).then(response => response.json());
 }
 
-export function fetchCoursesFromServer() {
-  return fetch(`${SERVER_URL}/courses`)
+export function fetchCoursesFromServer(filters = COURSE_FILTERS_INITIAL_STATE) {
+  const filtersWithValueOnly = mapValues(filters, 'value');
+  const query = QueryString.stringify(filtersWithValueOnly, {
+    encode: false,
+  });
+  return fetch(`${SERVER_URL}/courses` + (query && '?' + query))
     .then(response => response.json())
     .then(json => json.result);
 }

--- a/client/src/components/meetup/MeetupCommentList/MeetupCommentList.module.scss
+++ b/client/src/components/meetup/MeetupCommentList/MeetupCommentList.module.scss
@@ -1,6 +1,7 @@
 @use '../../../styles/variables.scss' as *;
 
 .container {
+  color: $color-grey-800;
   border: $border-grey;
   border-radius: 0.3rem;
   margin-bottom: 2rem;
@@ -17,19 +18,14 @@
 
 .top {
   display: flex;
-  gap: 1rem;
+  justify-content: space-between;
   align-items: center;
   margin-bottom: 1rem;
 }
 
 .top__data {
   display: flex;
-  gap: 0.5rem;
   align-items: center;
-
-  & .nickname {
-    color: $color-grey-800;
-  }
 
   & .avatar {
     width: 2.5rem;
@@ -37,13 +33,17 @@
     object-fit: cover;
     border-radius: 50%;
   }
+
+  & .nickname {
+    margin-left: 0.5rem;
+  }
 }
 
 .createdAt {
   color: $color-grey-500;
+  margin-left: 1rem;
 }
 
 .content {
-  color: $color-grey-800;
   line-height: 1.5;
 }

--- a/client/src/components/meetup/MeetupJoinBar/index.tsx
+++ b/client/src/components/meetup/MeetupJoinBar/index.tsx
@@ -11,7 +11,6 @@ import { useParams } from 'react-router-dom';
 import Confirm from 'components/common/Confirm';
 
 function getMeetupJoinFailErrorMessage(code: string) {
-  console.log(code);
   switch (code) {
     case '2038':
       return '참가 가능한 연령이 아닙니다.';

--- a/client/src/components/mypage/JoinedMeetupItem/JoinedMeetupItem.module.scss
+++ b/client/src/components/mypage/JoinedMeetupItem/JoinedMeetupItem.module.scss
@@ -13,7 +13,6 @@
   display: flex;
   gap: 2rem;
   justify-content: space-between;
-  align-items: center;
   margin-bottom: 1rem;
 
   & a {
@@ -51,6 +50,7 @@
 }
 
 .exit-btn {
+  align-self: flex-start;
   flex-shrink: 0;
   font-size: 1.3rem;
   display: flex;

--- a/client/src/components/mypage/ModifierForm/ModifierForm.module.scss
+++ b/client/src/components/mypage/ModifierForm/ModifierForm.module.scss
@@ -43,6 +43,11 @@
   }
 }
 
+.help-text {
+  color: $color-grey-600;
+  font-size: 1.3rem;
+}
+
 .fields {
   display: flex;
   flex-direction: column;

--- a/client/src/components/mypage/ModifierForm/index.tsx
+++ b/client/src/components/mypage/ModifierForm/index.tsx
@@ -36,6 +36,8 @@ interface ModifierForm {
   introduce: string;
 }
 
+const IMG_MAX_SIZE = 1024 * 1024;
+
 const ModifierForm = () => {
   const userProfile = useRecoilValue(userProfileState) as UserProfile;
   const userProfileCacheRefresher = useRecoilCacheRefresh(userProfileState);
@@ -69,12 +71,15 @@ const ModifierForm = () => {
   const onSubmit: SubmitHandler<ModifierForm> = data => {
     const imgData = new FormData();
     if (imgFile?.length) {
+      if (imgFile[0].size > IMG_MAX_SIZE) {
+        showToastMessage('이미지 파일 크기를 확인해 주세요.');
+        return;
+      }
       imgData.append('profile-img', imgFile[0]);
     }
 
     let newProfile = { ...data };
     delete newProfile.profileImgUrl;
-    console.log(newProfile);
 
     if (imgFile?.length) {
       axios
@@ -89,12 +94,13 @@ const ModifierForm = () => {
           'Content-Type': 'application/json',
         },
       })
-      .then(response => console.log(response)) // 성공 핸들링
-      .catch(error => console.log(error));
+      .then(() => {
+        showToastMessage('정보가 변경되었습니다.');
+        setTimeout(() => window.location.replace('/'), 2900);
+      })
+      .catch(() => showToastMessage('정보 변경 중 문제가 발생했습니다.'));
 
-    showToastMessage('정보가 변경되었습니다.');
-    userProfileCacheRefresher();
-    window.location.replace('/mypage');
+    // userProfileCacheRefresher();
     //navigate('/mypage');
   };
 
@@ -119,6 +125,9 @@ const ModifierForm = () => {
           />
           <label htmlFor={cn('img')}>편집</label>
         </div>
+        <p className={cn('help-text')}>
+          * 1MB 이내의 파일을 첨부할 수 있습니다.
+        </p>
         <div className={cn('fields')}>
           <div className={cn('field')}>
             <h3 className={cn('label')}>닉네임</h3>

--- a/client/src/components/mypage/MyMeetupItem/MyMeetupItem.module.scss
+++ b/client/src/components/mypage/MyMeetupItem/MyMeetupItem.module.scss
@@ -13,7 +13,6 @@
   display: flex;
   gap: 2rem;
   justify-content: space-between;
-  align-items: center;
   margin-bottom: 1rem;
 
   & a {
@@ -51,6 +50,7 @@
 }
 
 .close-btn {
+  align-self: flex-start;
   flex-shrink: 0;
   font-size: 1.3rem;
   display: flex;

--- a/client/src/routes/Home/index.tsx
+++ b/client/src/routes/Home/index.tsx
@@ -15,13 +15,14 @@ import CourseList from 'components/home/CourseList';
 import MeetupList from 'components/home/MeetupList';
 import { getMeetupsOrderedBy } from 'utils/order';
 import { MEETUP_FILTERS_INITIAL_STATE } from 'states/meetup';
+import { COURSE_FILTERS_INITIAL_STATE } from 'states/course';
 
 const cn = classNames.bind(styles);
 
 const Home = () => {
   const showToastMessage = useSetRecoilState(toastMessageState);
   const { data: courses } = useQuery<ServerIRoads[]>(
-    ['serverCourses'],
+    ['serverCourses', COURSE_FILTERS_INITIAL_STATE],
     fetchCoursesFromServer
   );
   const mainCourses = _.sortBy(courses, 'likeCount').reverse().slice(0, 3);

--- a/client/src/routes/Roads/Roads.module.scss
+++ b/client/src/routes/Roads/Roads.module.scss
@@ -19,7 +19,7 @@
 .filter-order {
   display: flex;
   font-size: 1.4rem;
-  //   justify-content: space-between;
+  // justify-content: space-between;
   justify-content: flex-end;
   margin-bottom: 1.5rem;
   @include for-tablet-landscape-up {

--- a/client/src/states/course.ts
+++ b/client/src/states/course.ts
@@ -14,7 +14,7 @@ export const CoursePageState = atom({
 });
 
 export const COURSE_FILTERS_INITIAL_STATE = {
-  location: { value: '전체', content: '전체' },
+  // location: { value: '전체', content: '전체' },
 };
 
 export const courseFiltersState = atom<CourseFiltersState>({

--- a/client/src/utils/filter.ts
+++ b/client/src/utils/filter.ts
@@ -130,6 +130,7 @@ function courseFiltersDispatchForRemoving(
       throw new Error();
   }
 }
+// 안 씀
 function courseFiltersDispatchForToggling(
   state: CourseFiltersState,
   { key }: FiltersReducerPayload
@@ -146,12 +147,7 @@ function courseFiltersDispatchForClearing(
   state: CourseFiltersState,
   { key }: FiltersReducerPayload
 ) {
-  switch (key) {
-    case 'location':
-      return { ...state, ...COURSE_FILTERS_INITIAL_STATE };
-    default:
-      return omit(state, [key]);
-  }
+  return omit(state, [key]);
 }
 export const COURSE_FILTERS_DISPATCHES = {
   choose: courseFiltersDispatchForChoosing,


### PR DESCRIPTION
## 관련 이슈

closes #196

## 작업 내용

#### 코스 필터링 로직 (빌드 X 상태)

로직은 짜두고 필터는 숨겨놨는데, 백엔드 필터 API 수정이 필요하지 않나 싶습니다.

우선 coursesAPI 파일의 `fetchFilteredCourses` 가 POST 요청을 해야 하는데 그 이유를 잘 모르겠기도 하고, 그 외에도 `fetchCourseFromServer` 와 `fetchFilteredCourses` 의 백엔드 API가 분리되어 있기 때문에, `Roads` 페이지에서 필터 유무에 따라 어떤 API를 호출할지 or 어떤 리스트를 렌더링해줄지에 대한 코드를 짜야 해서 복잡해질 것 같습니다.

제 생각엔 일반 코스 리스트 API가 `/courses` GET 요청이라면, 필터 시에는 `/courses?location=서울` 등과 같이 GET 요청을 하는 방식이 좋지 않을까 싶습니다. (모임 필터에서는 그렇게 진행했습니다.) 일단 위 방식이라는 가정하에 잘 짠 것인진 모르겠지만 관련 코드를 짜두었습니다.

그리고 코스 필터 dispatch 함수와 코스 default state 값의 오류가 그간의 에러 원인이지 않을까 싶습니다 😢

#### 프로필 사진 파일 크기 제한, 정보 변경 완료 시 알림 (빌드 O -> 사이트 반영된 상태)

파일 크기 제한 관련 help text를 적어 놓았고, 우선은 큰 파일 업로드 상태에서 정보 변경 버튼을 누른다면 toast 메세지가 뜨며 API가 호출되지 않도록 했습니다. 그런데 react hook form API를 살펴보면 큰 파일이 업로드 됐을 때 바로 alert 해줄 수 있는 기능이 있을 듯 합니다.

그리고 정보 변경 완료 시 `setTimeout` 을 통해 toast 메세지가 사라지고나서 다른 페이지로 리다이렉트 될 수 있도록 했습니다.
