### PR TITLE
refactor: 프론트엔드 리팩토링

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,5 @@
 import { Suspense, lazy, useEffect } from 'react';
 import { Routes, Route, useLocation } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
-import { userIdState } from 'states/auth';
-import { authAPI } from 'apis/authAPI';
 import Layout from 'routes/Layout';
 import Home from 'routes/Home';
 import Roads from 'routes/Roads';
@@ -34,6 +31,7 @@ import ModifyProfile from 'routes/Mypage/ModifyProfile';
 import ErrorBoundary from 'components/common/ErrorBoundary';
 import Auth from 'routes/Auth';
 import ComingSoon from 'components/common/ComingSoon';
+import useAuthAPI from 'hooks/useAuthAPI';
 
 declare module '@emotion/react' {
   export interface Theme extends MuiTheme {}
@@ -62,10 +60,9 @@ interface locationProps {
 const Error404 = lazy(() => import('components/common/Error404'));
 
 const App = () => {
-  const setUserId = useSetRecoilState(userIdState);
-  const { silentRefresh } = authAPI;
+  const { silentlyRefreshAccessToken } = useAuthAPI();
   useEffect(() => {
-    silentRefresh(setUserId);
+    silentlyRefreshAccessToken();
   }, []);
 
   const location = useLocation() as locationProps;
@@ -111,6 +108,7 @@ const App = () => {
                     path="meetups/bookmark"
                     element={<BookmarkedMeetups />}
                   />
+                  <Route path="delete_account" element={<DeleteAccount />} />
                 </Route>
               </Route>
 
@@ -123,8 +121,6 @@ const App = () => {
                   {/* <Route path="reset_password" element={<ResetPassword />} /> */}
                 </Route>
               </Route>
-
-              <Route path="delete_account" element={<DeleteAccount />} />
 
               <Route path="*" element={<Error404 />} />
             </Route>

--- a/client/src/components/common/Error404/Error404.module.scss
+++ b/client/src/components/common/Error404/Error404.module.scss
@@ -13,5 +13,5 @@
 .title {
   font-size: 2.4rem;
   font-weight: 700;
-  margin-top: 2rem;
+  margin: 2rem 0 3rem 0;
 }

--- a/client/src/components/common/Error404/index.tsx
+++ b/client/src/components/common/Error404/index.tsx
@@ -1,14 +1,27 @@
 import styles from './Error404.module.scss';
 import classNames from 'classnames/bind';
 import { TbFaceIdError } from 'react-icons/tb';
+import { useNavigate } from 'react-router-dom';
+import Button from '../Button';
 
 const cn = classNames.bind(styles);
 
-const Error404 = () => (
-  <section className={cn('wrapper')}>
-    <TbFaceIdError />
-    <h1 className={cn('title')}>존재하지 않는 페이지입니다.</h1>
-  </section>
-);
+const Error404 = () => {
+  const navigate = useNavigate();
+  const handleGoClick = () => navigate('/');
+  return (
+    <section className={cn('wrapper')}>
+      <TbFaceIdError />
+      <h1 className={cn('title')}>존재하지 않는 페이지입니다.</h1>
+      <Button
+        type="button"
+        color="main"
+        size="md"
+        content="메인으로 이동"
+        onClick={handleGoClick}
+      />
+    </section>
+  );
+};
 
 export default Error404;

--- a/client/src/components/common/ErrorBoundary/ErrorBoundary.module.scss
+++ b/client/src/components/common/ErrorBoundary/ErrorBoundary.module.scss
@@ -15,3 +15,7 @@
   font-weight: 700;
   margin: 2rem 0;
 }
+
+.content {
+  margin-bottom: 3rem;
+}

--- a/client/src/components/common/ErrorBoundary/index.tsx
+++ b/client/src/components/common/ErrorBoundary/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styles from './ErrorBoundary.module.scss';
 import { TbFaceIdError } from 'react-icons/tb';
 import { Outlet } from 'react-router-dom';
+import Button from '../Button';
 
 const cn = classNames.bind(styles);
 
@@ -33,6 +34,15 @@ export default class ErrorBoundary extends React.Component<
         <p className={cn('content')}>
           문제가 지속될 시 관리자에게 문의해 주세요.
         </p>
+        <Button
+          type="button"
+          color="main"
+          size="md"
+          content="메인으로 이동"
+          onClick={() => {
+            location.href = '/';
+          }}
+        />
       </section>
     ) : (
       <Outlet />

--- a/client/src/components/login/LoginForm/index.tsx
+++ b/client/src/components/login/LoginForm/index.tsx
@@ -1,15 +1,14 @@
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
-import { userIdState } from 'states/auth';
 import { toastMessageState } from 'states/common';
-import { authAPI } from 'apis/authAPI';
 import AuthFormInput from 'components/common/AuthFormInput';
 import ErrorMessage from 'components/common/ErrorMessage';
 import CheckBox from 'components/common/CheckBox';
 import Button from 'components/common/Button';
 import styles from './LoginForm.module.scss';
 import classNames from 'classnames/bind';
+import useAuthAPI from 'hooks/useAuthAPI';
 
 const cn = classNames.bind(styles);
 
@@ -50,7 +49,7 @@ const LoginForm = () => {
   const navigate = useNavigate();
 
   // Callbacks
-  const setUserId = useSetRecoilState(userIdState);
+  const { login } = useAuthAPI();
   const showToastMessage = useSetRecoilState(toastMessageState);
   const onSubmit: SubmitHandler<LoginForm> = async ({
     email,
@@ -58,7 +57,7 @@ const LoginForm = () => {
     isAuto,
   }) => {
     try {
-      await authAPI.login(email, password, isAuto, setUserId);
+      await login(email, password, isAuto);
       navigate(nextURL || '/');
     } catch (e: any) {
       showToastMessage(getLoginFailErrorMessage(e.message));

--- a/client/src/components/meetups/MeetupFilterBoard/index.tsx
+++ b/client/src/components/meetups/MeetupFilterBoard/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames/bind';
 import { useSetRecoilState } from 'recoil';
 import { meetupBoardFiltersState, meetupFiltersState } from 'states/meetup';
 import { SubmitHandler } from 'types/callback';
-import useClientFilter from 'hooks/useClientFilter';
+import useFilter from 'hooks/useFilter';
 import { toastMessageState } from 'states/common';
 import MeetupFilterChoices from '../MeetupFilterChoices';
 import { MEETUP_FILTERS_REDUCERS } from 'utils/filter';
@@ -16,7 +16,7 @@ interface MeetupFilterBoardProp {
 }
 
 const MeetupFilterBoard = ({ close }: MeetupFilterBoardProp) => {
-  const { filters: boardFilters, handleReset } = useClientFilter(
+  const { filters: boardFilters, handleReset } = useFilter(
     meetupBoardFiltersState,
     MEETUP_FILTERS_REDUCERS
   );

--- a/client/src/components/meetups/MeetupFilterBoardOptions/index.tsx
+++ b/client/src/components/meetups/MeetupFilterBoardOptions/index.tsx
@@ -15,7 +15,7 @@ import { FiltersReducerPayload } from 'types/common';
 import { meetupBoardFiltersState } from 'states/meetup';
 import { ChangeHandler, ClickHandler } from 'types/callback';
 import PlusMinusButton from 'components/common/PlusMinusButton';
-import useClientFilter from 'hooks/useClientFilter';
+import useFilter from 'hooks/useFilter';
 import { MEETUP_FILTERS_REDUCERS } from 'utils/filter';
 import FilterOptionChip from 'components/common/FilterOptionChip';
 import RidingSkills from 'components/common/RidingSkills';
@@ -35,7 +35,7 @@ const MeetupFilterBoardOptions = () => {
     handleRemove,
     handleToggle,
     handleClear,
-  } = useClientFilter(meetupBoardFiltersState, MEETUP_FILTERS_REDUCERS);
+  } = useFilter(meetupBoardFiltersState, MEETUP_FILTERS_REDUCERS);
 
   useEffect(() => {
     const min = boardFilters.minNumOfParticipants.value;

--- a/client/src/components/meetups/MeetupFilterChoices/index.tsx
+++ b/client/src/components/meetups/MeetupFilterChoices/index.tsx
@@ -5,7 +5,7 @@ import {
   meetupFiltersState,
   MEETUP_FILTERS_INITIAL_STATE,
 } from 'states/meetup';
-import useClientFilter from 'hooks/useClientFilter';
+import useFilter from 'hooks/useFilter';
 import { MEETUP_FILTERS_REDUCERS } from 'utils/filter';
 import classNames from 'classnames/bind';
 import { useEffect } from 'react';
@@ -19,7 +19,7 @@ interface MeetupFilterChoicesProp {
 
 const MeetupFilterChoices = ({ onBoard }: MeetupFilterChoicesProp) => {
   const state = onBoard ? meetupBoardFiltersState : meetupFiltersState;
-  const { filters, handleRemove, handleClear, handleReset } = useClientFilter(
+  const { filters, handleRemove, handleClear, handleReset } = useFilter(
     state,
     MEETUP_FILTERS_REDUCERS
   );

--- a/client/src/components/roads/CourseFilterBoard/index.tsx
+++ b/client/src/components/roads/CourseFilterBoard/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames/bind';
 import { useSetRecoilState } from 'recoil';
 import { courseBoardFiltersState, courseFiltersState } from 'states/course';
 import { SubmitHandler } from 'types/callback';
-import useClientFilter from 'hooks/useClientFilter';
+import useFilter from 'hooks/useFilter';
 import CourseFilterChoices from '../CourseFilterChoices';
 import { COURSE_FILTERS_DISPATCHES } from 'utils/filter';
 import CourseFilterBoardOptions from '../CourseFilterBoardOptions';
@@ -15,7 +15,7 @@ interface CourseFilterBoardProp {
 }
 
 const CourseFilterBoard = ({ close }: CourseFilterBoardProp) => {
-  const { filters: boardFilters, handleReset } = useClientFilter(
+  const { filters: boardFilters, handleReset } = useFilter(
     courseBoardFiltersState,
     // @ts-ignore
     COURSE_FILTERS_DISPATCHES

--- a/client/src/components/roads/CourseFilterBoardOptions/index.tsx
+++ b/client/src/components/roads/CourseFilterBoardOptions/index.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect } from 'react';
 import { FilterOptionData, FiltersReducerPayload } from 'types/common';
 import { courseBoardFiltersState } from 'states/course';
 import { ChangeHandler, ClickHandler } from 'types/callback';
-import useClientFilter from 'hooks/useClientFilter';
+import useFilter from 'hooks/useFilter';
 import { COURSE_FILTERS_DISPATCHES } from 'utils/filter';
 import FilterOptionChip from 'components/common/FilterOptionChip';
 
@@ -27,7 +27,7 @@ const CourseFilterBoardOptions = () => {
     handleToggle,
     handleClear,
     // @ts-ignore
-  } = useClientFilter(courseBoardFiltersState, COURSE_FILTERS_DISPATCHES);
+  } = useFilter(courseBoardFiltersState, COURSE_FILTERS_DISPATCHES);
 
   const toggleSpecificOption = useCallback(
     (payload: FiltersReducerPayload) => () => handleToggle(payload),

--- a/client/src/components/roads/CourseFilterChoices/index.tsx
+++ b/client/src/components/roads/CourseFilterChoices/index.tsx
@@ -6,7 +6,7 @@ import {
   COURSE_FILTERS_INITIAL_STATE,
 } from 'states/course';
 import { FilterOptionData } from 'types/common';
-import useClientFilter from 'hooks/useClientFilter';
+import useFilter from 'hooks/useFilter';
 import { COURSE_FILTERS_DISPATCHES } from 'utils/filter';
 import classNames from 'classnames/bind';
 import { useEffect } from 'react';
@@ -20,7 +20,7 @@ interface CourseFilterChoicesProp {
 
 const CourseFilterChoices = ({ onBoard }: CourseFilterChoicesProp) => {
   const state = onBoard ? courseBoardFiltersState : courseFiltersState;
-  const { filters, handleRemove, handleReset } = useClientFilter(
+  const { filters, handleRemove, handleReset } = useFilter(
     state,
     // @ts-ignore
     COURSE_FILTERS_DISPATCHES

--- a/client/src/components/signup/SignupBasicForm/index.tsx
+++ b/client/src/components/signup/SignupBasicForm/index.tsx
@@ -1,14 +1,15 @@
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { authAPI } from 'apis/authAPI';
-import { useSetRecoilState } from 'recoil';
-import { useSignupStepControls } from 'routes/Auth/Signup';
+import {
+  useSignupFormDataContext,
+  useSignupStepControls,
+} from 'routes/Auth/Signup';
 import AuthFormInput from 'components/common/AuthFormInput';
 import ErrorMessage from 'components/common/ErrorMessage';
 import { getSignupFormFieldErrorMessage } from 'utils/getErrorMessage';
 import Button from 'components/common/Button';
 import styles from './SignupBasicForm.module.scss';
 import classNames from 'classnames/bind';
-import { signupFormDataState } from 'states/auth';
 import { REGEX } from 'utils/regex';
 
 const cn = classNames.bind(styles);
@@ -53,7 +54,7 @@ const SignupBasicForm = () => {
     }
   };
 
-  const setSignupFormData = useSetRecoilState(signupFormDataState);
+  const { data, setData } = useSignupFormDataContext();
   const { decreaseStep, increaseStep } = useSignupStepControls();
   const onSubmit: SubmitHandler<SignupBasicForm> = async ({
     email,
@@ -61,7 +62,7 @@ const SignupBasicForm = () => {
   }) => {
     const isEmailValid = await validateEmail(email);
     if (!isEmailValid) return;
-    setSignupFormData(data => ({ ...data, email, password }));
+    setData(data => ({ ...data, email, password }));
     increaseStep();
   };
 

--- a/client/src/components/signup/SignupCompleted/index.tsx
+++ b/client/src/components/signup/SignupCompleted/index.tsx
@@ -3,20 +3,18 @@ import { useNavigate } from 'react-router-dom';
 import Button from 'components/common/Button';
 import styles from './SignupCompleted.module.scss';
 import classNames from 'classnames/bind';
-import { useRecoilValue, useResetRecoilState } from 'recoil';
-import { signupFormDataState } from 'states/auth';
-import { useEffect } from 'react';
 import { CgCheckO } from 'react-icons/cg';
+import { useSignupFormDataContext } from 'routes/Auth/Signup';
 
 const cn = classNames.bind(styles);
 
 const SignupCompleted = () => {
-  const { email, nickname } = useRecoilValue(signupFormDataState);
-  const resetSignupFormData = useResetRecoilState(signupFormDataState);
-  useEffect(() => resetSignupFormData, []);
-
+  const {
+    data: { email, nickname },
+  } = useSignupFormDataContext();
   const navigate = useNavigate();
   const handleLoginClick = () => navigate('/auth/login');
+
   return (
     <div className={cn('wrapper')}>
       <CgCheckO />

--- a/client/src/components/signup/SignupDetailForm/index.tsx
+++ b/client/src/components/signup/SignupDetailForm/index.tsx
@@ -1,7 +1,10 @@
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { toastMessageState } from 'states/common';
-import { useRecoilState, useSetRecoilState } from 'recoil';
-import { useSignupStepControls } from 'routes/Auth/Signup';
+import { useSetRecoilState } from 'recoil';
+import {
+  useSignupFormDataContext,
+  useSignupStepControls,
+} from 'routes/Auth/Signup';
 import { authAPI } from 'apis/authAPI';
 import AuthFormInput from 'components/common/AuthFormInput';
 import ErrorMessage from 'components/common/ErrorMessage';
@@ -11,7 +14,6 @@ import SelectList from 'components/common/SelectList';
 import Button from 'components/common/Button';
 import styles from './SignupDetailForm.module.scss';
 import classNames from 'classnames/bind';
-import { signupFormDataState } from 'states/auth';
 import {
   BICYCLE_TYPE_OPTIONS,
   GENDER_OPTIONS,
@@ -64,8 +66,10 @@ const SignupDetailForm = () => {
     }
   };
 
-  const [{ email, password }, setSignupFormData] =
-    useRecoilState(signupFormDataState);
+  const {
+    data: { email, password },
+    setData,
+  } = useSignupFormDataContext();
   const showToastMessage = useSetRecoilState(toastMessageState);
   const { decreaseStep, increaseStep } = useSignupStepControls();
   const onSubmit: SubmitHandler<SignupDetailForm> = async ({
@@ -91,7 +95,7 @@ const SignupDetailForm = () => {
 
     try {
       await authAPI.signup(newUser);
-      setSignupFormData(data => ({ ...data, nickname }));
+      setData(data => ({ ...data, nickname }));
       increaseStep();
     } catch (e) {
       showToastMessage('회원가입 중 문제가 발생했습니다.');

--- a/client/src/hooks/useAuthAPI.ts
+++ b/client/src/hooks/useAuthAPI.ts
@@ -1,0 +1,59 @@
+import { joyrideAxios as axios } from 'apis/axios';
+import { userAPI } from 'apis/userAPI';
+import useSetUserId from './useSetUserId';
+
+const JWT_EXPIRY_TIME_IN_SECONDS = 20 * 60;
+
+const useAuthAPI = () => {
+  const setUserId = useSetUserId();
+
+  const silentlyRefreshAccessTokenAfterInterval = () =>
+    setTimeout(
+      silentlyRefreshAccessToken,
+      (JWT_EXPIRY_TIME_IN_SECONDS - 5) * 1000
+    );
+
+  const handleAuthenticationSuccess = (accessToken: string, userId: number) => {
+    axios.defaults.headers.common.Authorization = accessToken;
+    setUserId(userId);
+    silentlyRefreshAccessTokenAfterInterval();
+  };
+
+  const login = async (email: string, password: string, isAuto: boolean) => {
+    const {
+      data: { code, result },
+    } = await axios.post('/auth/signin' + (isAuto ? '/auto' : ''), {
+      email,
+      password,
+    });
+
+    if (code !== 1000) {
+      throw new Error(code);
+    }
+    handleAuthenticationSuccess(result.accessToken, result.userId);
+  };
+
+  const silentlyRefreshAccessToken = async () => {
+    const {
+      data: { code, result },
+    } = await axios.post('/auth/jwt');
+
+    // 유효한 로그인 상태일 때 (유효한 refresh token)
+    if (code === 1000) {
+      handleAuthenticationSuccess(result.accessToken, result.userId);
+      return;
+    }
+
+    if (code === 2003) {
+      window.alert('로그인 유지 토큰이 만료되어 로그아웃됩니다.');
+    }
+    userAPI.handleLogout(setUserId);
+  };
+
+  return {
+    login,
+    silentlyRefreshAccessToken,
+  };
+};
+
+export default useAuthAPI;

--- a/client/src/hooks/useAuthAPI.ts
+++ b/client/src/hooks/useAuthAPI.ts
@@ -10,7 +10,7 @@ const useAuthAPI = () => {
   const silentlyRefreshAccessTokenAfterInterval = () =>
     setTimeout(
       silentlyRefreshAccessToken,
-      (JWT_EXPIRY_TIME_IN_SECONDS - 5) * 1000
+      (JWT_EXPIRY_TIME_IN_SECONDS - 3) * 1000
     );
 
   const handleAuthenticationSuccess = (accessToken: string, userId: number) => {

--- a/client/src/hooks/useFilter.ts
+++ b/client/src/hooks/useFilter.ts
@@ -13,7 +13,7 @@ interface FiltersReducers {
   clear: FiltersReducer<FiltersState>;
 }
 
-export const useClientFilter = (
+export const useFilter = (
   recoilState: RecoilState<FiltersState>,
   { choose, remove, toggle, clear }: FiltersReducers
 ) => {
@@ -51,4 +51,4 @@ export const useClientFilter = (
   };
 };
 
-export default useClientFilter;
+export default useFilter;

--- a/client/src/hooks/useSetUserId.ts
+++ b/client/src/hooks/useSetUserId.ts
@@ -1,0 +1,9 @@
+import { useSetRecoilState } from 'recoil';
+import { userIdState } from 'states/auth';
+
+const useSetUserId = () => {
+  const setUserId = useSetRecoilState(userIdState);
+  return setUserId;
+};
+
+export default useSetUserId;

--- a/client/src/routes/Auth/Signup/index.tsx
+++ b/client/src/routes/Auth/Signup/index.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState } from 'react';
-import { SignupStepControls } from 'types/auth';
+import { SignupFormData, SignupStepControls } from 'types/auth';
 import PageTitle from 'components/common/PageTitle';
 import SignupForms from 'components/signup/SignupForms';
 import SignupCompleted from 'components/signup/SignupCompleted';
@@ -8,22 +8,25 @@ import classNames from 'classnames/bind';
 
 const cn = classNames.bind(styles);
 
-const SignupStepControlsContext = createContext<SignupStepControls>({
-  decreaseStep: () => {},
-  increaseStep: () => {},
-});
+const SignupStepControlsContext = createContext({});
 export const useSignupStepControls = () =>
   useContext(SignupStepControlsContext);
 
+const SignupFormDataContext = createContext({});
+export const useSignupFormDataContext = () => useContext(SignupFormDataContext);
+
 const TOTAL_STEPS = 3;
+const INITIAL_SIGNUP_FORM_DATA = { email: '', password: '', nickname: '' };
 
 const Signup = () => {
-  // TODO: recoil
   const [step, setStep] = useState<number>(1);
   const decreaseStep = () => setStep(step => step - 1);
   const increaseStep = () => setStep(step => step + 1);
 
-  if (step > TOTAL_STEPS) return <SignupCompleted />;
+  const [signupFormData, setSignupFormData] = useState<SignupFormData>(
+    INITIAL_SIGNUP_FORM_DATA
+  );
+
   return (
     <SignupStepControlsContext.Provider
       value={{
@@ -31,16 +34,24 @@ const Signup = () => {
         increaseStep,
       }}
     >
-      <>
-        <header className={cn('header')}>
-          <PageTitle size="lg">회원가입</PageTitle>
-          <div className={cn('steps')}>
-            <span className={cn('current')}>{step}</span>
-            <span className={cn('total')}>/{TOTAL_STEPS}</span>
-          </div>
-        </header>
-        <SignupForms step={step} totalSteps={TOTAL_STEPS} />
-      </>
+      <SignupFormDataContext.Provider
+        value={{ data: signupFormData, setData: setSignupFormData }}
+      >
+        {step <= TOTAL_STEPS ? (
+          <>
+            <header className={cn('header')}>
+              <PageTitle size="lg">회원가입</PageTitle>
+              <div className={cn('steps')}>
+                <span className={cn('current')}>{step}</span>
+                <span className={cn('total')}>/{TOTAL_STEPS}</span>
+              </div>
+            </header>
+            <SignupForms step={step} totalSteps={TOTAL_STEPS} />
+          </>
+        ) : (
+          <SignupCompleted />
+        )}
+      </SignupFormDataContext.Provider>
     </SignupStepControlsContext.Provider>
   );
 };

--- a/client/src/routes/Roads/index.tsx
+++ b/client/src/routes/Roads/index.tsx
@@ -27,7 +27,7 @@ import {
 import { getCoursesOrderedBy } from 'utils/order';
 import { COURSE_FILTERS_DISPATCHES } from 'utils/filter';
 import { IRoad, ServerIRoads } from 'types/course';
-import useClientFilter from 'hooks/useClientFilter';
+import useFilter from 'hooks/useFilter';
 import NoResults from 'components/common/NoResults';
 
 const cn = classNames.bind(styles);

--- a/client/src/states/auth.ts
+++ b/client/src/states/auth.ts
@@ -1,6 +1,6 @@
 import { userAPI } from 'apis/userAPI';
 import { atom, selector } from 'recoil';
-import { SignupFormData, UserProfile } from 'types/auth';
+import { UserProfile } from 'types/auth';
 
 export const userIdState = atom<number | null>({
   key: 'userId',
@@ -13,9 +13,4 @@ export const userProfileState = selector<UserProfile | null>({
     if (!userId) return null;
     return await userAPI.getProfile(userId);
   },
-});
-
-export const signupFormDataState = atom<SignupFormData>({
-  key: 'signupFormData',
-  default: { email: '', password: '', nickname: '' },
 });


### PR DESCRIPTION
## 관련 이슈

#198 

## 작업 내용

- `authAPI`의 로그인 관련 로직을 `useAuthAPI` hook에 작성
- `signupFormData` recoil 대신 `useState`로 관리
- hooks 폴더 세분화 (but 지금의 폴더 구조가 최선인지는..?)

추가 예정